### PR TITLE
Make config keys match channel names

### DIFF
--- a/bin/afternoon_seal.sh
+++ b/bin/afternoon_seal.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 teams=(
-  data-informed-content
-  porg-pages
-  reliability-engineering
-  gov-uk-licensing-support
+  govuk-data-informed
+  govuk-porg-pages
+  r20g-infra-internal
+  govuk-licensing
 )
 
 for team in ${teams[*]} ; do

--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 teams=(
-  data-gov-uk
-  data-informed-content
-  govuk-design-system
-  platform-health
-  porg-pages
-  reliability-engineering
-  taxonomy-and-navigation
-  gov-uk-licensing-support
+  govuk-datagovuk-tech
+  govuk-data-informed
+  design-system-dev
+  govuk-platform-health
+  govuk-porg-pages
+  r20g-infra-internal
+  govuk-tax-and-nav
+  govuk-licensing
 )
 
 for team in ${teams[*]}; do

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -1,5 +1,5 @@
 # Please insert new items alphabetically.
-data-gov-uk:
+govuk-datagovuk-tech:
   members:
     - andrewgarner
     - benthorner
@@ -23,7 +23,7 @@ data-gov-uk:
     - datagovuk_find
     - datagovuk_infrastructure
 
-data-informed-content:
+govuk-data-informed:
   members:
     - chao-xian
     - kylemacpherson
@@ -59,7 +59,7 @@ data-informed-content:
     - Does your work have a story? Has your story got points?
     - I AM VENGEANCE! I AM THE NIGHT! I AM BATMAN! :batsignal:
 
-govuk-design-system:
+design-system-dev:
   members:
     - 36degrees
     - alex-ju
@@ -76,7 +76,7 @@ govuk-design-system:
     - DO NOT MERGE
     - WIP
 
-porg-pages:
+govuk-porg-pages:
   members:
     - andysellick
     - Davidslv
@@ -99,7 +99,7 @@ porg-pages:
     - These are not the organisation pages you are looking for
     - Migration is the path to the dark side. Migration leads to anger; anger leads to hate; hate leads to suffering. I sense much migration in you.
 
-platform-health:
+govuk-platform-health:
   members:
     - barrucadu
     - bevanloon
@@ -117,7 +117,7 @@ platform-health:
     - "[DO NOT MERGE]"
     - "WIP"
 
-reliability-engineering:
+r20g-infra-internal:
   members:
     - afda16
     - issyl0
@@ -137,7 +137,7 @@ reliability-engineering:
   quotes:
     - "Someone needs to think of some new quotes!"
 
-taxonomy-and-navigation:
+govuk-tax-and-nav:
   members:
     - 1pretz1
     - alextea
@@ -180,7 +180,7 @@ testing:
     - Be nice and respect each other. Support each other.
     - Don’t be a silo of knowledge
 
-gov-uk-licensing-support:
+govuk-licensing:
   members:
     - PeteLeaman
     - SomniGiggles


### PR DESCRIPTION
Otherwise, "seal me up" doesn't work, because it looks up the config
based on the channel name hubot passes it.

Currently we get an error like this:

```
2018-05-01T12:47:59.211453+00:00 app[web.1]: 2018-05-01 12:47:59 - NoMethodError - undefined method `[]' for nil:NilClass:
2018-05-01T12:47:59.211464+00:00 app[web.1]:     /app/lib/seal.rb:38:in `bark_at'
2018-05-01T12:47:59.211465+00:00 app[web.1]:     /app/lib/seal.rb:20:in `block in bark'
2018-05-01T12:47:59.211467+00:00 app[web.1]:     /app/lib/seal.rb:20:in `each'
2018-05-01T12:47:59.211469+00:00 app[web.1]:     /app/lib/seal.rb:20:in `bark'
2018-05-01T12:47:59.211471+00:00 app[web.1]:     /app/server.rb:15:in `block in <class:SealApp>'
```