### PR TITLE
Update members of GOV.UK Data Informed Content

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -28,9 +28,9 @@ govuk-data-informed:
     - chao-xian
     - kylemacpherson
     - matmoore
-    - peteglondon
     - pmanrubia
     - theKHutDeveloper
+    - tombye
 
   channel:
     "#govuk-data-informed"


### PR DESCRIPTION
Pete G has moved to Taxonomy and Tom Byers has joined Data Informed Content.