### PR TITLE
Add compact option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ export GITHUB_USE_LABELS=true
 export GITHUB_EXCLUDE_LABELS="[DO NOT MERGE],Don't merge,DO NOT MERGE,Waiting on factcheck,wip"
 export GITHUB_EXCLUDE_REPOS="notmyproject,someotherproject" # Ensure these projects are *NOT* included
 export GITHUB_INCLUDE_REPOS="definitelymyproject,forsuremyproject" # Ensure *only* these projects will be included
+export COMPACT=true # Use a more compact version of the seal output
 export SEAL_QUOTES="Everyone should have the opportunity to learn. Don’t be afraid to pick up stories on things you don’t understand and ask for help with them.,Try to pair when possible."
 ```
 

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -151,6 +151,8 @@ govuk-platform-health:
     - Slack as primary point of contact (email for long form stuff)
     - "[Get ready to form] sub teams on larger pieces of work"
 
+  compact: true
+
 govuk-content-pages:
   members:
     - andrewgarner

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -135,8 +135,16 @@ class MessageBuilder
     string.tr('&', '&amp;').tr('<', '&lt;').tr('>', '&gt;')
   end
 
+  def apply_style(template_name)
+    if team.compact
+      "#{template_name}.compact"
+    else
+      template_name
+    end
+  end
+
   def render(template_name)
-    template_file = TEMPLATE_DIR + "#{template_name}.text.erb"
+    template_file = TEMPLATE_DIR + "#{apply_style(template_name)}.text.erb"
     ERB.new(template_file.read).result(binding).strip
   end
 end

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -51,7 +51,9 @@ class MessageBuilder
       present(pr, n)
     }.join("\n")
 
-    @recent_pull_requests = pull_requests.reject { |pr| rotten?(pr) }
+    @recent_pull_requests = pull_requests.reject { |pr|
+      rotten?(pr) || pr[:approved]
+    }
 
     @list_recent_pull_requests = @recent_pull_requests.map.with_index(1) { |pr, n|
       present(pr, n)
@@ -61,7 +63,9 @@ class MessageBuilder
   end
 
   def list_pull_requests
-    @message = pull_requests.map.with_index(1) { |pr, n|
+    @message = pull_requests.reject{ |pr|
+      pr[:approved]
+    }.map.with_index(1) { |pr, n|
       present(pr, n)
     }.join("\n")
 

--- a/lib/seal.rb
+++ b/lib/seal.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
-require "message_builder"
-require "slack_poster"
+require_relative "message_builder"
+require_relative "slack_poster"
 
 # Entry point for the Seal!
 class Seal

--- a/lib/team.rb
+++ b/lib/team.rb
@@ -2,6 +2,7 @@ class Team
   def initialize(
                   members: nil,
                   use_labels: nil,
+                  compact: nil,
                   exclude_labels: nil,
                   exclude_titles: nil,
                   exclude_repos: nil,
@@ -11,6 +12,7 @@ class Team
                 )
     @members = members || []
     @use_labels = (use_labels.nil? ? false : use_labels)
+    @compact = (compact.nil? ? false : compact)
     @exclude_labels = exclude_labels || []
     @exclude_titles = exclude_titles || []
     @exclude_repos = exclude_repos || []
@@ -22,6 +24,7 @@ class Team
   attr_reader *%i[
     members
     use_labels
+    compact
     exclude_labels
     exclude_titles
     exclude_repos

--- a/lib/team_builder.rb
+++ b/lib/team_builder.rb
@@ -23,7 +23,7 @@ class TeamBuilder
 
   def build_single_team(team_name)
     [
-      Team.new(apply_env(static_config[team_name.to_sym])),
+      Team.new(apply_env(static_config[team_name.to_s] || {})),
     ]
   end
 

--- a/lib/team_builder.rb
+++ b/lib/team_builder.rb
@@ -35,15 +35,15 @@ class TeamBuilder
 
   def apply_env(config)
     {
-      members: env["GITHUB_MEMBERS"]&.split(",") || config[:members],
-      use_labels: env["GITHUB_USE_LABELS"] == "true" || config[:use_labels],
-      compact: env["COMPACT"] == "true" || config[:compact],
-      exclude_labels: env["GITHUB_EXCLUDE_LABELS"]&.split(',') || config[:exclude_labels],
-      exclude_titles: env["GITHUB_EXCLUDE_TITLES"]&.split(',') || config[:exclude_titles],
-      exclude_repos: env["GITHUB_EXCLUDE_REPOS"]&.split(',') || config[:exclude_repos],
-      include_repos: env["GITHUB_INCLUDE_REPOS"]&.split(',') || config[:include_repos],
-      quotes: env["SEAL_QUOTES"]&.split(',') || config[:quotes],
-      slack_channel: env["SLACK_CHANNEL"] || config[:channel],
+      members: env["GITHUB_MEMBERS"]&.split(",") || config["members"],
+      use_labels: env["GITHUB_USE_LABELS"] == "true" || config["use_labels"],
+      compact: env["COMPACT"] == "true" || config["compact"],
+      exclude_labels: env["GITHUB_EXCLUDE_LABELS"]&.split(',') || config["exclude_labels"],
+      exclude_titles: env["GITHUB_EXCLUDE_TITLES"]&.split(',') || config["exclude_titles"],
+      exclude_repos: env["GITHUB_EXCLUDE_REPOS"]&.split(',') || config["exclude_repos"],
+      include_repos: env["GITHUB_INCLUDE_REPOS"]&.split(',') || config["include_repos"],
+      quotes: env["SEAL_QUOTES"]&.split(',') || config["quotes"],
+      slack_channel: env["SLACK_CHANNEL"] || config["channel"],
     }
   end
 

--- a/lib/team_builder.rb
+++ b/lib/team_builder.rb
@@ -37,6 +37,7 @@ class TeamBuilder
     {
       members: env["GITHUB_MEMBERS"]&.split(",") || config[:members],
       use_labels: env["GITHUB_USE_LABELS"] == "true" || config[:use_labels],
+      compact: env["COMPACT"] == "true" || config[:compact],
       exclude_labels: env["GITHUB_EXCLUDE_LABELS"]&.split(',') || config[:exclude_labels],
       exclude_titles: env["GITHUB_EXCLUDE_TITLES"]&.split(',') || config[:exclude_titles],
       exclude_repos: env["GITHUB_EXCLUDE_REPOS"]&.split(',') || config[:exclude_repos],

--- a/spec/message_builder_spec.rb
+++ b/spec/message_builder_spec.rb
@@ -16,10 +16,21 @@ RSpec.describe MessageBuilder do
         repo: 'whitehall',
         comments_count: 5,
         thumbs_up: 0,
+        approved: false,
+        updated: Date.parse('2015-07-17 ((2457221j, 0s, 0n), +0s, 2299161j)'),
+        labels: [],
+      },
+      {
+        title: 'Some approved PR',
+        link: 'https://github.com/alphagov/whitehall/pull/9999',
+        author: 'helpful_person',
+        repo: 'whitehall',
+        comments_count: 5,
+        thumbs_up: 0,
         approved: true,
         updated: Date.parse('2015-07-17 ((2457221j, 0s, 0n), +0s, 2299161j)'),
         labels: [],
-      }
+      },
     ]
   end
 
@@ -98,8 +109,8 @@ RSpec.describe MessageBuilder do
   context 'pull requests are recent' do
     let(:pull_requests) { recent_pull_requests }
 
-    it 'builds informative message' do
-      expect(message_builder.build.text).to eq("Hello team!\n\nHere are the pull requests that need to be reviewed today:\n\n1) *whitehall* | tekin | updated yesterday | :white_check_mark: \n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\nMerry reviewing!")
+    it 'builds informative message excluding approved PRs' do
+      expect(message_builder.build.text).to eq("Hello team!\n\nHere are the pull requests that need to be reviewed today:\n\n1) *whitehall* | tekin | updated yesterday\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\nMerry reviewing!")
     end
 
     it 'has an informative poster mood' do

--- a/spec/message_builder_spec.rb
+++ b/spec/message_builder_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require './lib/message_builder'
 
 RSpec.describe MessageBuilder do
-  let(:team) { double(:team) }
+  let(:team) { double(:team, compact: false) }
   let(:github_fetcher) { double(:github_fetcher, list_pull_requests: pull_requests)}
   subject(:message_builder) { MessageBuilder.new(team) }
 
@@ -139,6 +139,16 @@ RSpec.describe MessageBuilder do
 
     it 'has an angry poster mood' do
       expect(message_builder.build.mood).to eq("angry")
+    end
+
+    context "when in compact mode" do
+      let(:team) { double(:team, compact: true) }
+
+      before { Timecop.freeze(Time.local(2015, 07, 18)) }
+
+      it "builds a more compact message" do
+        expect(message_builder.build.text).to eq("*Old pull requests*:\n1) whitehall: <https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host>\n\n*Recent pull requests*:\n1) whitehall: <https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code>\n2) seal: <https://github.com/alphagov/seal/pull/9999|Add extra examples to the specs>")
+      end
     end
   end
 

--- a/spec/team_builder_spec.rb
+++ b/spec/team_builder_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe TeamBuilder do
           "WIP",
         ],
         use_labels: true,
+        compact: true,
         quotes: [
           "This is a quote",
           "This is also a quote",
@@ -71,6 +72,7 @@ RSpec.describe TeamBuilder do
     ])
 
     expect(lions.use_labels).to eq(true)
+    expect(lions.compact).to eq(true)
 
     expect(lions.quotes).to eq([
       "This is a quote",
@@ -84,6 +86,7 @@ RSpec.describe TeamBuilder do
     expect(tigers.exclude_titles).to eq([])
     expect(tigers.exclude_labels).to eq([])
     expect(tigers.use_labels).to eq(false)
+    expect(tigers.compact).to eq(false)
     expect(tigers.quotes).to eq([])
     expect(tigers.include_repos).to eq([])
     expect(tigers.exclude_repos).to eq([])

--- a/spec/team_builder_spec.rb
+++ b/spec/team_builder_spec.rb
@@ -10,35 +10,35 @@ RSpec.describe TeamBuilder do
   before do
     FileUtils.mkdir_p(File.join(File.dirname(__FILE__), "../config"))
     File.write(File.join(File.dirname(__FILE__), "../config/#{organisation}.yml"), YAML.dump(
-      lions: {
-        members: [
+      "lions" => {
+        "members" => [
           "lil lion",
           "snoop lion",
           "biggy smalls",
         ],
-        channel: "#lions",
-        exclude_titles: [
+        "channel" => "#lions",
+        "exclude_titles" => [
           "DO NOT MERGE",
           "WIP",
         ],
-        exclude_labels: [
+        "exclude_labels" => [
           "DO NOT MERGE",
           "WIP",
         ],
-        use_labels: true,
-        compact: true,
-        quotes: [
+        "use_labels" => true,
+        "compact" => true,
+        "quotes" => [
           "This is a quote",
           "This is also a quote",
         ],
       },
-      tigers: {
-        members: [
+      "tigers" => {
+        "members" => [
           "tony",
           "stripey",
           "biggy smalls",
         ],
-        channel: "#tigers",
+        "channel" => "#tigers",
       },
     ))
   end

--- a/templates/_pull_request.compact.text.erb
+++ b/templates/_pull_request.compact.text.erb
@@ -1,0 +1,1 @@
+<%= @index %>) <%= @pr[:repo] %>: <<%= @pr[:link] %>|<%= html_encode(@pr[:title]) %>>

--- a/templates/old_pull_requests.compact.text.erb
+++ b/templates/old_pull_requests.compact.text.erb
@@ -1,0 +1,6 @@
+*Old pull requests*:
+<%= @angry_bark %>
+<% if !@recent_pull_requests.empty? %>
+*Recent pull requests*:
+<%= @list_recent_pull_requests %>
+<% end %>


### PR DESCRIPTION
Removes approved PRs from lists of fresh PRs and adds a `compact: true` / `COMPACT=true` config option which provides more compact PR output.

Before:
<img width="679" alt="screenshot 2018-07-27 11 08 57" src="https://user-images.githubusercontent.com/109225/43315392-c06537c6-918d-11e8-8b1a-427d9150bdf6.png">

After:
<img width="672" alt="screenshot 2018-07-27 11 10 02" src="https://user-images.githubusercontent.com/109225/43315396-c5bf0d6e-918d-11e8-8b84-22e1cee9cde0.png">

https://trello.com/c/JA6NvD5o/335-refactor-and-restyle-slack-seal-output