### PR TITLE
Ensure the team charter seal posts every week day

### DIFF
--- a/lib/slack_poster.rb
+++ b/lib/slack_poster.rb
@@ -100,7 +100,6 @@ class SlackPoster
       @mood = "tea"
     elsif @mood == nil
       @mood = "charter"
-      @postable_day = today.tuesday? || today.thursday?
     end
   end
 


### PR DESCRIPTION
Currently the Team Charter seal only posts on Tuesdays and Thursdays. Upon request from @hongoose, we want this to happen every day.