### PR TITLE
Add a compact version of the list_pull_requests template

### DIFF
--- a/templates/list_pull_requests.compact.text.erb
+++ b/templates/list_pull_requests.compact.text.erb
@@ -1,0 +1,2 @@
+*Recent pull requests*:
+<%= @message %>


### PR DESCRIPTION
This commit adds a compact version of the `list_pull_requests` template, which is used when there are outstanding PRs, but none of them are old.