### PR TITLE
ignore archived repositories

### DIFF
--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -56,7 +56,7 @@ class GithubFetcher
   # https://developer.github.com/v3/search/#search-issues
   # returns up to 100 results per page.
   def pull_requests_from_github
-    github.search_issues("is:pr state:open user:#{organisation}").items
+    github.search_issues("is:pr state:open user:#{organisation} archived:false").items
   end
 
   def person_subscribed?(pull_request)

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe GithubFetcher do
     allow(Octokit::Client).to receive(:new).and_return(fake_octokit_client)
     allow(fake_octokit_client).to receive_message_chain('user.login')
     allow(fake_octokit_client).to receive(:auto_paginate=).with(true)
-    allow(fake_octokit_client).to receive(:search_issues).with("is:pr state:open user:alphagov").and_return(double(items: [pull_2266, pull_2248]))
+    allow(fake_octokit_client).to receive(:search_issues).with("is:pr state:open user:alphagov archived:false").and_return(double(items: [pull_2266, pull_2248]))
 
     allow(fake_octokit_client).to receive(:issue_comments).with(whitehall_repo_name, 2266).and_return(comments_2266)
     allow(fake_octokit_client).to receive(:issue_comments).with(whitehall_rebuild_repo_name, 2248).and_return(comments_2248)


### PR DESCRIPTION
You can't do anything with PRs in archived repos (without unarchiving
them first), and you probably don't want to.

Fixes #26.