### PR TITLE
Rename teams

### DIFF
--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -7,7 +7,7 @@ teams=(
   govuk-platform-health
   govuk-pub-workflow
   govuk-content-pages
-  govuk-single-taxonomy
+  govuk-taxonomy
   govuk-step-by-step
   re-infra-internal
   re-observe

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -144,7 +144,7 @@ govuk-content-pages:
     - "[SPIKE]"
     - "[WIP]"
 
-govuk-single-taxonomy:
+govuk-taxonomy:
   members:
     - 1pretz1
     - cbaines
@@ -222,10 +222,9 @@ re-observe:
     - "[DO NOT MERGE]"
     - WIP
 
-testing:
+bot-testing:
   members:
     - binaryberry
-    - boffbowsh
 
   channel:
     "#bot-testing"

--- a/lib/slack_poster.rb
+++ b/lib/slack_poster.rb
@@ -104,6 +104,6 @@ class SlackPoster
   end
 
   def channel
-    @team_channel = '#angry-seal-bot-test' if ENV["DYNO"].nil?
+    @team_channel = '#bot-testing' if ENV["DYNO"].nil?
   end
 end


### PR DESCRIPTION
This commit makes team names match their Slack channel names. It also removes Paul, who has left.