### PR TITLE
Fix requests for non-existent team names

### DIFF
--- a/lib/team_builder.rb
+++ b/lib/team_builder.rb
@@ -22,9 +22,12 @@ class TeamBuilder
   attr_reader :env
 
   def build_single_team(team_name)
-    [
-      Team.new(apply_env(static_config[team_name.to_s] || {})),
-    ]
+    team = Team.new(apply_env(static_config[team_name.to_s] || {}))
+    if team.members.empty?
+      []
+    else
+      [team]
+    end
   end
 
   def build_all_teams

--- a/spec/team_builder_spec.rb
+++ b/spec/team_builder_spec.rb
@@ -106,4 +106,10 @@ RSpec.describe TeamBuilder do
     expect(teams.count).to eq(1)
     expect(teams.first.channel).to eq("#tigers")
   end
+
+  it "short-circuits if the team name does not appear in the configuration file" do
+    teams = TeamBuilder.build(env: env, team_name: "cheetas")
+
+    expect(teams.count).to eq(0)
+  end
 end


### PR DESCRIPTION
This commit fixes an issue where a request from a Slack channel that is not defined in the Seal would result in all PRs being posted to the default Slack channel for the webhook.