### PR TITLE
Reduce noise for finding-brexiters

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -31,7 +31,11 @@ govuk-finding-brexit:
   channel:
     "#govuk-finding-brexit"
 
+  compact: true
+
   exclude_titles:
+    - "[DO NOT MERGE]"
+    - "[PROTOTYPE]"
     - WIP
     - "[WIP]"
 


### PR DESCRIPTION
Added in some exclusions to reduce the noise in the morning.

Also using the `compact: true` option to reduce the space taken up by the
Seal bark (as there are quite a few of us).