### PR TITLE
Add edwardkerry to Platform Health

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -115,7 +115,6 @@ govuk-platform-health:
     - andreagrandi
     - barrucadu
     - bevanloon
-    - binaryberry
     - brucebolt
     - deborahchua
     - elliotcm
@@ -190,19 +189,3 @@ re-observe:
   exclude_titles:
     - "[DO NOT MERGE]"
     - WIP
-
-bot-testing:
-  members:
-    - binaryberry
-
-  channel:
-    "#bot-testing"
-
-  exclude_titles:
-    - "[DO NOT MERGE]"
-    - WIP
-
-  quotes:
-    - Everyone should have the opportunity to learn. Don’t be afraid to pick up stories on things you don’t understand and ask for help with them.
-    - Be nice and respect each other. Support each other.
-    - Don’t be a silo of knowledge

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -117,6 +117,7 @@ govuk-platform-health:
     - bevanloon
     - brucebolt
     - deborahchua
+    - edwardkerry
     - elliotcm
     - hongoose
     - rubenarakelyan


### PR DESCRIPTION
Tatiana has left GDS. She was also the only member of the `bot-testing` team. Remove binaryberry from Platform Health and also remove the `bot-testing` team.

Add Edward Kerry to Platform Health because Edward has just joined GDS and is on the Platform Health team. 👋 Welcome Edward!