### PR TITLE
Move Kat and Jonathan

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -22,6 +22,8 @@ digitalmarketplace:
     - benvand
     - lfdebrux
     - risicle
+    - jonodrew
+    - katstevens
 
   channel:
     "#dm-review"
@@ -138,8 +140,6 @@ govuk-platform-health:
     - rubenarakelyan
     - steventux
     - thomasleese
-    - jonodrew
-    - katstevens
 
   channel:
     "#govuk-platform-health"


### PR DESCRIPTION
Kat and Jonathan have moved (back) to Digital Marketplace from Platform Health. I've updated the config to reflect that.