### PR TITLE
Add new EUExit Ready team

### DIFF
--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -4,6 +4,7 @@ teams=(
   design-system-dev
   digitalmarketplace
   govuk-data-informed
+  govuk-euexit-ready
   govuk-finding-brexit
   govuk-licensing
   govuk-platform-health

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -31,6 +31,28 @@ digitalmarketplace:
   exclude_titles:
     - WIP
 
+govuk-euexit-ready:
+  members:
+    - vanitabarrett
+    - MuriloDalRi
+    - MahmudH
+    - peteglondon
+    - steventux
+    - leenagupte
+    - DilwoarH
+    - VitalieMogoreanu
+
+  channel:
+    "#govuk-euexit-ready"
+
+  compact: true
+
+  exclude_titles:
+    - "[DO NOT MERGE]"
+    - "[PROTOTYPE]"
+    - WIP
+    - "[WIP]"
+
 govuk-finding-brexit:
   members:
     - andrewgarner
@@ -40,7 +62,6 @@ govuk-finding-brexit:
     - koetsier
     - MahmudH
     - oscarwyatt
-    - peteglondon
     - sihugh
     - vanitabarrett
     - VitalieMogoreanu


### PR DESCRIPTION
The EU Exit Readiness team is a new team on GOV.UK.