### PR TITLE
Update platform health for q4 2018 2019

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -144,13 +144,11 @@ govuk-licensing:
 govuk-platform-health:
   members:
     - AlanGabbianelli
-    - andreagrandi
     - bevanloon
     - deborahchua
     - edwardkerry
     - elliotcm
     - hongoose
-    - rosafox
     - rubenarakelyan
     - thomasleese
 


### PR DESCRIPTION
Remove Andrea and Rosa from `govuk-platform-health`. Andrea has left GDS and Rosa has moved back to her usual team.