### PR TITLE
Remove Ollie from EU Exit Readiness

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -41,7 +41,6 @@ govuk-euexit-ready:
     - leenagupte
     - DilwoarH
     - VitalieMogoreanu
-    - 36degrees
 
   channel:
     "#govuk-euexit-ready"


### PR DESCRIPTION
Ollie is no longer on the EU Exit Readiness team