### PR TITLE
Remove #re-autom8

### DIFF
--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -12,7 +12,6 @@ teams=(
   govuk-platform-health
   govuk-pub-workflow
   govuk-search-perf
-  re-autom8
   re-infra-internal
 )
 

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -191,28 +191,6 @@ govuk-search-perf:
 
   compact: true
 
-re-autom8:
-  members:
-    - adityapahuja
-    - andy-paine
-    - bartlabo
-    - issyl0
-    - matthewcullum-gds
-    - mmhmm
-    - philandstuff
-    - sakisv
-    - stephengrier
-    - tlwr
-
-  channel:
-    "#re-autom8"
-
-  exclude_titles:
-    - "[DO NOT MERGE]"
-    - "WIP"
-
-  compact: true
-
 re-infra-internal:
   members:
     - afda16


### PR DESCRIPTION
- We find the live feed from GitHub => Slack more useful.