### PR TITLE
Remove the Seal from #re-infra-internal

### DIFF
--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -12,7 +12,6 @@ teams=(
   govuk-platform-health
   govuk-pub-workflow
   govuk-search-perf
-  re-infra-internal
 )
 
 for team in ${teams[*]}; do

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -191,30 +191,6 @@ govuk-search-perf:
 
   compact: true
 
-re-infra-internal:
-  members:
-    - afda16
-    - deanwilson
-    - fredericfran-gds
-    - jstandring-gds
-    - ronocg
-    - rtrinque
-    - schmie
-    - stephenharker
-    - th31nitiate
-
-  channel:
-    "#re-infra-internal"
-
-  exclude_titles:
-    - "[DO NOT MERGE]"
-    - WIP
-
-  quotes:
-    - "Someone needs to think of some new quotes!"
-
-  compact: true
-
 govuk-pay:
   members:
     - heathd


### PR DESCRIPTION
- The only contributor to this channel in the last few weeks is the
  Seal. Most GOV.UK discussion now takes place in #re-govuk, and the
  list of repos/people is old.