### PR TITLE
Remove the Search Performance & Resilience team

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -189,20 +189,6 @@ govuk-platform-health:
 
   compact: true
 
-govuk-search-perf:
-  members:
-    - barrucadu
-    - brucebolt
-
-  channel:
-    "#govuk-search-perf"
-
-  exclude_titles:
-    - "[DO NOT MERGE]"
-    - "WIP"
-
-  compact: true
-
 govuk-pay:
   members:
     - heathd


### PR DESCRIPTION
The team no longer exists 😢