### PR TITLE
Refresh config for govuk-pub-workflow

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -96,21 +96,14 @@ govuk-pub-workflow:
   members:
     - 1pretz1
     - alex-ju
-    - benhazell
     - benthorner
     - emmabeynon
-    - erino
     - kevindew
-    - kgarwood
-    - soniaturcotte
 
   channel:
-    "#govuk-pub-workflow"
+    "#govuk-pubworkflow-dev"
 
   exclude_titles:
-    - "[DO NOT MERGE]"
-    - "Don't merge"
-    - "DON'T MERGE"
     - "DO NOT MERGE"
     - "WIP"
 


### PR DESCRIPTION
This makes four changes to the config:

   - Removes non-developers, as we don't seem to get any value from
tracking their PRs (if any)
   - Removes people who've left GDS
   - Changes the channel to -dev, to avoid spamming our main channel
   - Removes all excluded titles until it's clear we need them