### PR TITLE
Remove draft PRs from seal display

### DIFF
--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -56,7 +56,7 @@ class GithubFetcher
   # https://developer.github.com/v3/search/#search-issues
   # returns up to 100 results per page.
   def pull_requests_from_github
-    github.search_issues("is:pr state:open user:#{organisation} archived:false").items
+    github.search_issues("is:pr state:open user:#{organisation} archived:false -is:draft").items
   end
 
   def person_subscribed?(pull_request)

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe GithubFetcher do
     allow(Octokit::Client).to receive(:new).and_return(fake_octokit_client)
     allow(fake_octokit_client).to receive_message_chain('user.login')
     allow(fake_octokit_client).to receive(:auto_paginate=).with(true)
-    allow(fake_octokit_client).to receive(:search_issues).with("is:pr state:open user:alphagov archived:false").and_return(double(items: [pull_2266, pull_2248]))
+    allow(fake_octokit_client).to receive(:search_issues).with("is:pr state:open user:alphagov archived:false -is:draft").and_return(double(items: [pull_2266, pull_2248]))
 
     allow(fake_octokit_client).to receive(:issue_comments).with(whitehall_repo_name, 2266).and_return(comments_2266)
     allow(fake_octokit_client).to receive(:issue_comments).with(whitehall_rebuild_repo_name, 2248).and_return(comments_2248)


### PR DESCRIPTION
Given the purpose of the seal is to remind people to take action towards
getting PRs reviewed and then merged, it doesn't particularly make sense
for these to include draft PRs. As the status of draft indicates a PR is
not ready to be merged.

Documentation to show drafts:
https://help.github.com/en/articles/searching-issues-and-pull-requests#search-for-draft-pull-requests
and exclude certain results:
https://help.github.com/en/articles/understanding-the-search-syntax#exclude-certain-results