### PR TITLE
Remove Steve Laing from EU Exit Readiness team

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -55,7 +55,6 @@ govuk-euexit-ready:
     - DilwoarH
     - leenagupte
     - oscarwyatt
-    - steventux
     - VitalieMogoreanu
 
   channel:


### PR DESCRIPTION
Steve has now moved to GovWifi 😭