### PR TITLE
Update publishing workflow for Q2 2019

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -52,7 +52,6 @@ govuk-cookies:
 govuk-euexit-ready:
   members:
     - AgaDufrat
-    - brucebolt
     - ChrisBAshton
     - DilwoarH
     - leenagupte
@@ -99,8 +98,12 @@ govuk-pub-workflow:
     - 1pretz1
     - alex-ju
     - benthorner
+    - brucebolt
     - emmabeynon
+    - JonathanHallam
     - kevindew
+    - Tetrino
+    - theseanything
 
   channel:
     "#govuk-pubworkflow-dev"


### PR DESCRIPTION
Adds new developers to publishing workflow team for Q2 2019.

This is when I realise my GitHub username is actually rather boring 🤔.