### PR TITLE
Skip deploying to integration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,7 @@
 library("govuk")
 
 node {
-  govuk.buildProject()
+  govuk.buildProject(
+    skipDeployToIntegration: true
+  )
 }


### PR DESCRIPTION
Automatic deployment of the seal is failing because the CI build is failing on the "Deploy to Integration"
step. As the seal is not deployed in AWS, we can remove this step.