### PR TITLE
Update design system team people

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -1,13 +1,11 @@
 # Please insert new items alphabetically.
 design-system-dev:
   members:
-    - aliuk2012
+    - 36degrees
     - amyhupe
     - dashouse
     - hannalaakso
-    - joelanman
     - nickcolley
-    - 36degrees
     - timpaul
 
   channel:


### PR DESCRIPTION
Remove Joe and Al as they're not working on the team right now. :v: 

Move Ollie to the top so the list is alphabetical...