### PR TITLE
Remove Publishing Workflow; Add Notifications team

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -95,20 +95,13 @@ govuk-taxonomy:
     - WIP
     - "[WIP]"
 
-govuk-pub-workflow:
+govuk-notifications:
   members:
     - 1pretz1
-    - alex-ju
-    - benthorner
-    - brucebolt
-    - emmabeynon
-    - JonathanHallam
     - kevindew
-    - Tetrino
-    - theseanything
 
   channel:
-    "#govuk-pubworkflow-dev"
+    "#govuk-notifications"
 
   exclude_titles:
     - "DO NOT MERGE"


### PR DESCRIPTION
This replaces the Publishing Workflow team 😢 with the newly spun up
(and tiny) Notifications team. I've only gone with adding the notifications
team since I don't know all the other team details and whether they want
the seal.