### PR TITLE
bv/specify-marketplace-repos

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -31,6 +31,38 @@ digitalmarketplace:
   exclude_titles:
     - WIP
 
+  include_repos:
+    - "digitalmarketplace-admin-frontend"
+    - "digitalmarketplace-agreements"
+    - "digitalmarketplace-antivirus-api"
+    - "digitalmarketplace-api"
+    - "digitalmarketplace-apiclient"
+    - "digitalmarketplace-aws"
+    - "digitalmarketplace-bad-words"
+    - "digitalmarketplace-brief-responses-frontend"
+    - "digitalmarketplace-briefs-frontend"
+    - "digitalmarketplace-buyer-frontend"
+    - "digitalmarketplace-content-loader"
+    - "digitalmarketplace-credentials"
+    - "digitalmarketplace-design-patterns"
+    - "digitalmarketplace-docker-base"
+    - "digitalmarketplace-frameworks"
+    - "digitalmarketplace-frontend-toolkit"
+    - "digitalmarketplace-functional-tests"
+    - "digitalmarketplace-jenkins"
+    - "digitalmarketplace-logdia"
+    - "digitalmarketplace-manual"
+    - "digitalmarketplace-performance-testing"
+    - "digitalmarketplace-router"
+    - "digitalmarketplace-runner"
+    - "digitalmarketplace-scripts"
+    - "digitalmarketplace-search-api"
+    - "digitalmarketplace-supplier-frontend"
+    - "digitalmarketplace-test-utils"
+    - "digitalmarketplace-user-frontend"
+    - "digitalmarketplace-utils"
+    - "digitalmarketplace-visual-regression"
+
   compact: false
 
 govuk-frontend-a11y:


### PR DESCRIPTION
Only specific Digital Marketplace repose should be flagged in the Digital Marketplace review channel