### PR TITLE
Add govuk-frontend-jinja to Digital Marketplace team

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -62,6 +62,7 @@ digitalmarketplace:
     - "digitalmarketplace-user-frontend"
     - "digitalmarketplace-utils"
     - "digitalmarketplace-visual-regression"
+    - "govuk-frontend-jinja"
 
   compact: false
 


### PR DESCRIPTION
Digital Marketplace also maintains the repo govuk-frontend-jinja, we should get alerts about PRs on that repo.