### PR TITLE
Update data-labs team

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -68,9 +68,14 @@ digitalmarketplace:
 
 govuk-data-labs:
   members:
-    - karlbaker02
-    - oscarwyatt
+    - bevanloon
     - ff-l
+    - karlbaker02
+    - mammykins
+    - nacnudus
+    - oscarwyatt
+    - suganya-s
+    - trvllngmn
 
   channel:
     "#govuk-data-labs"
@@ -144,7 +149,6 @@ govuk-platform-health:
   members:
     - AlanGabbianelli
     - benjamineskola
-    - bevanloon
     - callumknights
     - cbaines
     - deborahchua


### PR DESCRIPTION
Move Bevan from platform health to data labs.

Add Matthew, Duncan, Suganya and Franklin to data labs.

Put data labs team members in alphabetical order.