### PR TITLE
Add GOV.UK coronavirus services team

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -282,3 +282,21 @@ govuk-pub-workflow:
 
   exclude_repos:
     - "gds-way"
+
+govuk-corona-services:
+  members:
+    - alex-ju
+    - bilbof
+    - brucebolt
+    - huwd
+    - injms
+    - issyl0
+    - leenagupte
+    - richardTowers
+
+  channel:
+    "#govuk-corona-services-tech"
+
+  exclude_title:
+    - "DO NOT MERGE"
+    - "🚧"

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -258,15 +258,12 @@ govuk-pay:
 govuk-pub-workflow:
   members:
     - 1pretz1
-    - alex-ju
     - benthorner
-    - brucebolt
     - ChrisBAshton
     - emmabeynon
     - gclssvglx
     - JonathanHallam
     - kevindew
-    - leenagupte
     - Rosa-Fox
 
   channel:


### PR DESCRIPTION
Creates the new GOV.UK coronavirus services team, and updates the Publishing Workflow team.