### PR TITLE
Remove Issy from Platform Health

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -201,7 +201,6 @@ govuk-platform-health:
     - cbaines
     - deborahchua
     - edwardkerry
-    - issyl0
     - kentsanggds
     - MahmudH
     - MuriloDalRi


### PR DESCRIPTION
- They're on the Coronavirus Services team for the next three weeks.