### PR TITLE
Remove #govuk-licensing channel config

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -149,20 +149,6 @@ govuk-frontend-a11y:
     - "It's okay to take time to learn"
     - "It's okay not know everything"
 
-govuk-licensing:
-  members:
-    - PeteLeaman
-    - SomniGiggles
-    - steven-radford
-    - chrispapto
-
-  channel:
-    "#govuk-licensing"
-
-  exclude_titles:
-    - "[DO NOT MERGE]"
-    - "[WIP]"
-
 govuk-platform-health:
   members:
     - AlanGabbianelli


### PR DESCRIPTION
- Slack keeps 7 days of history. For the past 7 days, there haven't been
  any changes and it's just "aloha, no pull requests" making useless
  noise.