### PR TITLE
Update notifications team members

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -114,9 +114,8 @@ govuk-coronavirus-notifications:
   members:
     - benthorner
     - kevindew
-    - koetsier
+    - chao-xian
     - laurentqro
-    - theseanything
     - vanitabarrett
 
   channel:


### PR DESCRIPTION
Update the notifications team:

- Jos is on shared parental leave
- Sean has moved to a coronavirus forms team
- Kelvin has joined the team