### PR TITLE
Make the Seal noisy in the correct team channels

### DIFF
--- a/bin/afternoon_seal.sh
+++ b/bin/afternoon_seal.sh
@@ -3,11 +3,8 @@
 teams=(
   govuk-corona-product
   govuk-coronavirus-notifications
-  govuk-data-informed
   govuk-frontend-a11y
-  govuk-licensing
   govuk-platform-health
-  govuk-searchandnav
   govuk-step-by-step
 )
 

--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -4,16 +4,12 @@ teams=(
   design-system-dev
   digitalmarketplace
   govuk-corona-product
+  govuk-corona-services
   govuk-coronavirus-notifications
   govuk-data-labs
   govuk-frontend-a11y
-  govuk-data-informed
-  govuk-searchandnav
-  govuk-licensing
   govuk-pay
   govuk-platform-health
-  govuk-pub-workflow
-  govuk-taxonomy
 )
 
 for team in ${teams[*]}; do


### PR DESCRIPTION
- Turns out that *this* is how you add new teams to the Seal!
- This also removes a load of teams that no longer have config.
- It would be nice if we could automatically infer these from the
  `config/alphagov.yml` keys, as it took me a while to remember
  how to actually configure a new team to post, but that's for
  another day...