### PR TITLE
Refine the Coronavirus Services team alerts

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -261,3 +261,11 @@ govuk-corona-services:
   exclude_title:
     - "DO NOT MERGE"
     - "🚧"
+    - "[WIP]"
+    - "[Do Not Merge]"
+
+  include_repos:
+    - govuk-coronavirus-business-volunteer-form
+    - govuk-coronavirus-find-support
+    - govuk-coronavirus-vulnerable-people-form
+    - govuk-developer-docs


### PR DESCRIPTION
Only show PRs for repos being worked on by this team, and also increases the list of ignored WIP titles.