### PR TITLE
Add a data.gov.uk team to the Seal

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -177,6 +177,21 @@ govuk-frontend-a11y:
     - "It's okay to take time to learn"
     - "It's okay not know everything"
 
+govuk-datagovuk:
+  members:
+    - kentsanggds
+    - maxgds
+    - risicle
+
+  channel:
+    "#govuk-datagovuk"
+
+  exclude_titles:
+    - "[DO NOT MERGE]"
+    - "[PROTOTYPE]"
+    - WIP
+    - "[WIP]"
+
 govuk-platform-health:
   members:
     - 1pretz1


### PR DESCRIPTION
This is more for the DGU Upgrade team, so Ken is part of both Platform Health and DGU.