### PR TITLE
Fix typo in configuration file

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -273,7 +273,7 @@ govuk-corona-services:
   channel:
     "#govuk-corona-services-tech"
 
-  exclude_title:
+  exclude_titles:
     - "DO NOT MERGE"
     - "🚧"
     - "[WIP]"


### PR DESCRIPTION
Seal was reporting PRs that should have been excluded because of a typo in the configuration file.