### PR TITLE
Remove people from Platform Health team

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -193,9 +193,7 @@ govuk-datagovuk:
 
 govuk-platform-health:
   members:
-    - 1pretz1
     - AlanGabbianelli
-    - barrucadu
     - beccapearce
     - benjamineskola
     - callumknights
@@ -204,7 +202,6 @@ govuk-platform-health:
     - deborahchua
     - edwardkerry
     - kentsanggds
-    - MahmudH
     - MuriloDalRi
     - nicholsj
     - Tetrino


### PR DESCRIPTION
These people have moved on to different teams.