### PR TITLE
Tidy up and add accounts

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -163,7 +163,7 @@ govuk-data-labs:
 govuk-datagovuk:
   members:
     - kentsanggds
-    - maxgds
+    - owenatgov
     - risicle
 
   channel:

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -139,24 +139,6 @@ govuk-brexit-content-team:
     - WIP
     - "[WIP]"
 
-govuk-coronavirus-notifications:
-  members:
-    - benthorner
-    - chao-xian
-    - laurentqro
-    - vanitabarrett
-
-  channel:
-    "#govuk-coronavirus-notifications"
-
-  compact: true
-
-  exclude_titles:
-    - "[DO NOT MERGE]"
-    - "[PROTOTYPE]"
-    - WIP
-    - "[WIP]"
-
 govuk-data-labs:
   members:
     - bevanloon
@@ -213,6 +195,24 @@ govuk-datagovuk:
 
   channel:
     "#govuk-datagovuk"
+
+  exclude_titles:
+    - "[DO NOT MERGE]"
+    - "[PROTOTYPE]"
+    - WIP
+    - "[WIP]"
+
+govuk-notifications:
+  members:
+    - 1pretz1
+    - benthorner
+    - kevindew
+    - laurentqro
+
+  channel:
+    "#govuk-notifications-dev"
+
+  compact: true
 
   exclude_titles:
     - "[DO NOT MERGE]"

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -139,6 +139,32 @@ govuk-brexit-content-team:
     - WIP
     - "[WIP]"
 
+govuk-corona-services:
+  members:
+    - alex-ju
+    - gclssvglx
+    - GDSNewt
+    - JonathanHallam
+    - leenagupte
+    - reggieb
+    - Rosa-Fox
+    - steveholmes
+
+  channel:
+    "#govuk-corona-services-tech"
+
+  exclude_titles:
+    - "DO NOT MERGE"
+    - "🚧"
+    - "[WIP]"
+    - "[Do Not Merge]"
+
+  include_repos:
+    - govuk-coronavirus-business-volunteer-form
+    - govuk-coronavirus-find-support
+    - govuk-coronavirus-vulnerable-people-form
+    - govuk-developer-docs
+
 govuk-data-labs:
   members:
     - chao-xian
@@ -281,30 +307,19 @@ govuk-pay:
     - "[DO NOT MERGE]"
     - WIP
 
-govuk-corona-services:
+govuk-replatforming:
   members:
-    - alex-ju
     - bilbof
-    - gclssvglx
-    - GDSNewt
-    - injms
+    - deanwilson
     - issyl0
-    - JonathanHallam
-    - leenagupte
-    - Rosa-Fox
-    - steveholmes
+    - MahmudH
+    - richardTowers
+    - seb-szy
 
   channel:
-    "#govuk-corona-services-tech"
+    "#govuk-replatforming"
 
   exclude_titles:
-    - "DO NOT MERGE"
-    - "🚧"
+    - "[DO NOT MERGE]"
+    - WIP
     - "[WIP]"
-    - "[Do Not Merge]"
-
-  include_repos:
-    - govuk-coronavirus-business-volunteer-form
-    - govuk-coronavirus-find-support
-    - govuk-coronavirus-vulnerable-people-form
-    - govuk-developer-docs

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -141,7 +141,7 @@ govuk-brexit-content-team:
 
 govuk-data-labs:
   members:
-    - bevanloon
+    - chao-xian
     - ff-l
     - karlbaker02
     - mammykins

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -123,15 +123,14 @@ govuk-accounts:
     - "We know we can't do this alone. We need to work with teams across GDS and government to succeed."
     - "We invest time and effort in increasing our understanding of the problems we’re working on. This will help us make things better for users and move the conversation about personalisation in government forward."
 
-govuk-corona-product:
+govuk-brexit-content-team:
   members:
-    - andysellick
     - DilwoarH
     - hannako
     - sihugh
 
   channel:
-    "#govuk-corona-product"
+    "#govuk-brexit-content-team"
 
   compact: true
 

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -177,7 +177,7 @@ govuk-datagovuk:
 
 govuk-frontend-a11y:
   members:
-    - chao-xian
+    - danacotoran
     - injms
     - maxgds
 

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -93,6 +93,36 @@ digitalmarketplace:
 
   compact: false
 
+govuk-accounts:
+  members:
+    - andysellick
+    - barrucadu
+    - bevanloon
+    - brucebolt
+    - erino
+    - huwd
+
+  channel:
+    "#govuk-accounts"
+
+  exclude_titles:
+    - "[DO NOT MERGE]"
+    - "[PROTOTYPE]"
+    - WIP
+    - "[WIP]"
+
+  quotes:
+    - "We put users first. We strive to create services that bring real value to our users and that meet their needs and expectations."
+    - "We believe users should feel safe and confident when they use our services."
+    - "We design for everyone. We think about under-represented audiences from the start and check our biases throughout the design process."
+    - "We’re comfortable challenging assumptions and asking difficult questions. We speak truth to power."
+    - "We’re OK with change, failure, ambiguity, and adapting our approach."
+    - "We work collaboratively. Our work does not happen in discipline silos and we value the contributions of every discipline equally."
+    - "We treat each other with integrity, honesty and respect."
+    - "We work in the open so users and government colleagues know what we’re doing and why."
+    - "We know we can't do this alone. We need to work with teams across GDS and government to succeed."
+    - "We invest time and effort in increasing our understanding of the problems we’re working on. This will help us make things better for users and move the conversation about personalisation in government forward."
+
 govuk-corona-product:
   members:
     - andysellick

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -160,6 +160,21 @@ govuk-data-labs:
     - WIP
     - "[WIP]"
 
+govuk-datagovuk:
+  members:
+    - kentsanggds
+    - maxgds
+    - risicle
+
+  channel:
+    "#govuk-datagovuk"
+
+  exclude_titles:
+    - "[DO NOT MERGE]"
+    - "[PROTOTYPE]"
+    - WIP
+    - "[WIP]"
+
 govuk-frontend-a11y:
   members:
     - chao-xian
@@ -186,21 +201,6 @@ govuk-frontend-a11y:
     - "It's okay to depend on the team"
     - "It's okay to take time to learn"
     - "It's okay not know everything"
-
-govuk-datagovuk:
-  members:
-    - kentsanggds
-    - maxgds
-    - risicle
-
-  channel:
-    "#govuk-datagovuk"
-
-  exclude_titles:
-    - "[DO NOT MERGE]"
-    - "[PROTOTYPE]"
-    - WIP
-    - "[WIP]"
 
 govuk-notifications:
   members:


### PR DESCRIPTION
The Seal is a little out of date so...

Add the accounts team and the replatforming team.

Alphabetise datagovuk and govuk-corona-services.

Update some teams so they more accurately reflect the people on them.

I expect there's more work to get this completely accurate. Work for another day though.