### PR TITLE
Allow teams without members

### DIFF
--- a/lib/team_builder.rb
+++ b/lib/team_builder.rb
@@ -23,7 +23,7 @@ class TeamBuilder
 
   def build_single_team(team_name)
     team = Team.new(apply_env(static_config[team_name.to_s] || {}))
-    if team.members.empty?
+    if team.channel.nil?
       []
     else
       [team]


### PR DESCRIPTION
On the accounts team, we have two slack channels:

* govuk-account-tech - a channel specifically for the developers.
* govuk-accounts - the channel for the whole multidisciplinary team.

We want PRs to alert in govuk-accounts-tech, but team quotes to alert in
govuk-accounts. The govuk-accounts team is configured without team
members, but with quotes and a slack channel.

Current logic short-circuits if a team has no team members. The intent
of this was to [stop the seal alerting with all PRs when someone pings
the seal from a slack channel that isn't defined in the config](https://github.com/alphagov/seal/pull/52).

Changing the logic to test for a `slack_channel` instead of `members`
should retain the short circuit but also allow us to send quotes to slack channels
without needing to have team members.

A definition of a team is "a number of persons associated together in work or activity",
This PR now means we can have a "team" without members. Naming things is hard.
Future us might want to rethink the domain a bit.

I also considered just adding a team member to the govuk-accounts team. The 
disadvantage would be that the govuk-accounts team would see PRs for that
team member which is functionality we don't want.