### PR TITLE
GOV.UK Pay: Exclude PRs containing '[DRAFT]' in the title

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -317,6 +317,7 @@ govuk-pay:
 
   exclude_titles:
     - "[DO NOT MERGE]"
+    - "[DRAFT]"
     - WIP
 
 govuk-replatforming:


### PR DESCRIPTION
Pay's seal bot appears to have been angry about a particular draft PR for some time. Let's calm it down.