### PR TITLE
Rename notifications team

### DIFF
--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -6,7 +6,7 @@ teams=(
   govuk-accounts-tech
   govuk-corona-product
   govuk-corona-services
-  govuk-coronavirus-notifications
+  govuk-notifications
   govuk-data-labs
   govuk-frontend-a11y
   govuk-pay

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -247,7 +247,7 @@ govuk-notifications:
     - kevindew
 
   channel:
-    "#govuk-notifications-dev"
+    "#govuk-notifications"
 
   compact: true
 

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -245,7 +245,6 @@ govuk-notifications:
     - 1pretz1
     - benthorner
     - kevindew
-    - laurentqro
 
   channel:
     "#govuk-notifications-dev"


### PR DESCRIPTION
They are no longer the govuk-coronavirus-notifications team, they're scope is all the broader as govuk-notifications.