### PR TITLE
Remove cbaines from govuk-platform-health

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -207,7 +207,7 @@ govuk-data-labs:
     - whojammyflip
     - ZacharyForrest
     - zilnhoj
-    
+
   channel:
     "#govuk-data-labs"
 
@@ -297,7 +297,6 @@ govuk-platform-health:
     - beccapearce
     - benjamineskola
     - callumknights
-    - cbaines
     - ChrisBAshton
     - deborahchua
     - edwardkerry


### PR DESCRIPTION
He's no longer working in the team.