### PR TITLE
Remove govuk-notifications team

### DIFF
--- a/bin/afternoon_seal.sh
+++ b/bin/afternoon_seal.sh
@@ -4,7 +4,6 @@ teams=(
   digitalmarketplace-team
   govuk-accounts
   govuk-corona-product
-  govuk-coronavirus-notifications
   govuk-data-labs
   govuk-frontend-a11y
   govuk-platform-health

--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -6,7 +6,6 @@ teams=(
   govuk-accounts-tech
   govuk-corona-product
   govuk-corona-services
-  govuk-notifications
   govuk-data-labs
   govuk-frontend-a11y
   govuk-pay

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -161,6 +161,7 @@ govuk-accounts-tech:
 
 govuk-brexit-content-team:
   members:
+    - benthorner
     - DilwoarH
     - hannako
     - sihugh
@@ -179,6 +180,7 @@ govuk-corona-services:
   members:
     - GDSNewt
     - JonathanHallam
+    - kevindew
     - leenagupte
     - Rosa-Fox
     - steveholmes
@@ -281,25 +283,9 @@ govuk-frontend-a11y:
     - "It's okay to take time to learn"
     - "It's okay not know everything"
 
-govuk-notifications:
-  members:
-    - 1pretz1
-    - benthorner
-    - kevindew
-
-  channel:
-    "#govuk-notifications"
-
-  compact: true
-
-  exclude_titles:
-    - "[DO NOT MERGE]"
-    - "[PROTOTYPE]"
-    - WIP
-    - "[WIP]"
-
 govuk-platform-health:
   members:
+    - 1pretz1
     - AlanGabbianelli
     - beccapearce
     - benjamineskola


### PR DESCRIPTION
https://trello.com/c/GHfDidG0/656-disable-slack-notifications-as-part-of-pausing-the-team

This team is being paused. Note that "govuk-coronavirus-notifications"
also no longer exists (was renamed to "govuk-notifications").