### PR TITLE
Update repos for digitalmarketplace team seal

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -72,7 +72,7 @@ digitalmarketplace:
     - "digitalmarketplace-buyer-frontend"
     - "digitalmarketplace-content-loader"
     - "digitalmarketplace-credentials"
-    - "digitalmarketplace-design-patterns"
+    - "digitalmarketplace-developer-tools"
     - "digitalmarketplace-docker-base"
     - "digitalmarketplace-frameworks"
     - "digitalmarketplace-frontend-toolkit"


### PR DESCRIPTION
Remove https://github.com/alphagov/digitalmarketplace-patterns as it is unused and should be archived. Add new repo https://github.com/alphagov/digitalmarketplace-developer-tools.