### PR TITLE
Remove Dana from govuk-frontend-a11y members list

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -260,7 +260,6 @@ govuk-datagovuk:
 
 govuk-frontend-a11y:
   members:
-    - danacotoran
     - injms
     - maxgds
 


### PR DESCRIPTION
Seal is still spamming `govuk-frontend-a11y` channel with notifications of my PRs in various repos.

I'm working on GOVUK Accounts now so I've removed myself from the a11y team members list.