### PR TITLE
Update seal config for accessibility team and datagovuk channels

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -246,8 +246,6 @@ govuk-data-labs:
 govuk-datagovuk:
   members:
     - kentsanggds
-    - owenatgov
-    - risicle
 
   channel:
     "#govuk-datagovuk"
@@ -258,13 +256,15 @@ govuk-datagovuk:
     - WIP
     - "[WIP]"
 
-govuk-frontend-a11y:
+govuk-accessibility-team:
   members:
     - injms
     - maxgds
+    - owenatgov
+    - chris-gds
 
   channel:
-    "#govuk-frontend-a11y"
+    "#govuk-accessibility-team"
 
   compact: true
 
@@ -273,16 +273,6 @@ govuk-frontend-a11y:
     - "[PROTOTYPE]"
     - WIP
     - "[WIP]"
-
-  quotes:
-    - "Be Excellent To Each Other!"
-    - ":smiling-batman:"
-    - "Don't be working if you're ill!"
-    - ":green_heart:"
-    - "It's okay to ask for help"
-    - "It's okay to depend on the team"
-    - "It's okay to take time to learn"
-    - "It's okay not know everything"
 
 govuk-platform-health:
   members:


### PR DESCRIPTION
- Changes the name of the accessibility team channel from `govuk-frontend-a11y` to `govuk-accessibility-team`
- Adds @owenatgov and @chris-gds as team members
- Removes quotes from the team config as the team doesn't feel they bring any value
- Removes Owen and @risicle from `govuk-datagovuk` as they're no longer on that team