### PR TITLE
Update the config for govwifi

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -387,9 +387,10 @@ govwifi:
     - koetsier
     - camdesgov
     - sarahseewhy
-    - Ian-Nicholls
-    - cchani
     - seb-szy
+    - cbaines
+    - szd55gds
+    - jimnarey
 
   include_repos:
     - govwifi-acceptance-tests


### PR DESCRIPTION
Remove people who've left the team, and add new additions.