### PR TITLE
Temporarily add CCS to DMp seal team

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -55,6 +55,8 @@ digitalmarketplace:
     - domoscargin
     - bjgill
     - daniele-occhipinti
+    - ghill95
+    - ccs-jamie-e
 
   channel:
     "#dm-2ndline"

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -57,7 +57,7 @@ digitalmarketplace:
     - daniele-occhipinti
 
   channel:
-    "#dm-review"
+    "#dm-2ndline"
 
   exclude_titles:
     - WIP


### PR DESCRIPTION
Move the seal alerts to the Slack channel CCS team members have access to and add them to the team