### PR TITLE
Fully remove GOV.UK Design System team

### DIFF
--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 teams=(
-  design-system-dev
   digitalmarketplace
   govuk-accounts-tech
   govuk-corona-products


### PR DESCRIPTION
Closes https://github.com/alphagov/design-system-team-internal/issues/484 🤞 

Remove design system team from morning seal. I missed this from PR #246.

We're still getting messages from the seal, I'm not sure why, but I want to make sure this isn't something to do with it.