### PR TITLE
Tidy up seal config for govuk accessibility and explore team

### DIFF
--- a/bin/afternoon_seal.sh
+++ b/bin/afternoon_seal.sh
@@ -5,7 +5,6 @@ teams=(
   govuk-data-labs
   govuk-explore-devs
   govuk-explore-navigation
-  govuk-frontend-a11y
   govuk-platform-health
   govuk-step-by-step
 )

--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -5,8 +5,6 @@ teams=(
   govuk-corona-products
   govuk-data-labs
   govuk-explore-devs
-  govuk-explore-navigation
-  govuk-frontend-a11y
   govuk-pay
   govuk-platform-health
   govwifi

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -154,7 +154,6 @@ govuk-explore-devs:
     - "[WIP]"
 
 govuk-explore-navigation:
-
   channel:
     "#govuk-explore-navigation"
 


### PR DESCRIPTION
## What/Why
Does the following:

- Removes `govuk-frontend-a11y` from the repo as this channel no longer exists
- Removes `govuk-explore-navigation` from the morning seal as w have a separate dev channel for the angry seal and this channel just this morning got blasted with all the dependabot PR's currently open across alphagov