### PR TITLE
Remove colinbm from govwifi

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -254,7 +254,6 @@ govuk-replatforming:
 
 govwifi:
   members:
-    - colinbm
     - koetsier
     - camdesgov
     - sarahseewhy


### PR DESCRIPTION
As sadly he's not currently on the team.