### PR TITLE
Change the Slack channel for the GovWifi team

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -287,7 +287,7 @@ govwifi:
     - govwifi-watchdog
 
   channel:
-    "#govwifi-monitoring"
+    "#govwifi-sre-dev-magic-"
 
   exclude_titles:
     - "[DO NOT MERGE]"


### PR DESCRIPTION
Since the seal's posts in #govwifi-monitoring get a bit lost.