### PR TITLE
Add GOV.UK Publishing team

### DIFF
--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -7,6 +7,7 @@ teams=(
   govuk-explore-devs
   govuk-pay
   govuk-platform-health
+  govuk-publishing
   govwifi
 )
 

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -233,6 +233,22 @@ govuk-pay:
     - "[DRAFT]"
     - WIP
 
+govuk-publishing:
+  members:
+    - beccapearce
+    - brucebolt
+    - kevindew
+    - spikeheap
+
+  channel:
+    "#govuk-publishing-tech"
+
+  exclude_title:
+    - "[DO NOT MERGE]"
+    - "WIP"
+
+  compact: true
+
 govuk-replatforming:
   members:
     - bilbof


### PR DESCRIPTION
This is a newly formed team, so adding us to the daily seal alerts for outstanding PRs.