### PR TITLE
Escape hypens in config file

### DIFF
--- a/bin/afternoon_seal.sh
+++ b/bin/afternoon_seal.sh
@@ -6,7 +6,7 @@ teams=(
   govuk-explore-devs
   govuk-explore-navigation
   govuk-platform-health
-  govuk-step-by-step
+  govuk-corona-products
 )
 
 for team in ${teams[*]} ; do

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -2,7 +2,7 @@
 govuk-accessibility-team:
   members:
     - maxgds
-    - chris-gds
+    - "chris-gds"
     - edwardkerry
 
   channel:
@@ -70,7 +70,7 @@ govuk-corona-products:
     - JonathanHallam
     - kevindew
     - leenagupte
-    - Rosa-Fox
+    - "Rosa-Fox"
 
   channel:
     "#govuk-corona-services-tech"
@@ -89,8 +89,8 @@ govuk-data-labs:
     - maxf
     - nacnudus
     - oscarwyatt
-    - st-alice
-    - suganya-s
+    - "st-alice"
+    - "suganya-s"
     - VitalieMogoreanu
     - ZacharyForrest
     - zilnhoj
@@ -141,7 +141,7 @@ govuk-datagovuk:
 
 govuk-explore-devs:
   members:
-    - chao-xian
+    - "chao-xian"
     - injms
     - owenatgov
 
@@ -205,13 +205,13 @@ govuk-pay:
     - crispinfugds
     - danworth
     - dasarindra
-    - dj-maisy
+    - "dj-maisy"
     - gidsg
     - heathd
     - iqbalgds
     - jabrahoarder
     - jfharden
-    - jonny-walkley
+    - "jonny-walkley"
     - katstevens
     - kbottla
     - mrlumbu
@@ -223,7 +223,7 @@ govuk-pay:
     - SandorArpa
     - sfount
     - stephencdaly
-    - xander-gds
+    - "xander-gds"
     - sjzarb
 
   channel:
@@ -257,7 +257,7 @@ govuk-replatforming:
     - issyl0
     - MahmudH
     - richardTowers
-    - seb-szy
+    - "seb-szy"
 
   channel:
     "#govuk-replatforming"
@@ -272,33 +272,33 @@ govwifi:
     - koetsier
     - camdesgov
     - sarahseewhy
-    - seb-szy
+    - "seb-szy"
     - cbaines
     - szd55gds
     - jimnarey
 
   include_repos:
-    - govwifi-acceptance-tests
-    - govwifi-admin
-    - govwifi-authentication-api
-    - govwifi-build
-    - govwifi-builder-task
-    - govwifi-concourse-deploy-pipeline
-    - govwifi-concourse-runner
-    - govwifi-dashboard
-    - govwifi-database-backup
-    - govwifi-dev-docs
-    - govwifi-frontend
-    - govwifi-logging-api
-    - govwifi-product-page
-    - govwifi-redirect
-    - govwifi-safe-restarter
-    - govwifi-shared-frontend
-    - govwifi-smoke-tests
-    - govwifi-tech-docs
-    - govwifi-terraform
-    - govwifi-user-signup-api
-    - govwifi-watchdog
+    - "govwifi-acceptance-tests"
+    - "govwifi-admin"
+    - "govwifi-authentication-api"
+    - "govwifi-build"
+    - "govwifi-builder-task"
+    - "govwifi-concourse-deploy-pipeline"
+    - "govwifi-concourse-runner"
+    - "govwifi-dashboard"
+    - "govwifi-database-backup"
+    - "govwifi-dev-docs"
+    - "govwifi-frontend"
+    - "govwifi-logging-api"
+    - "govwifi-product-page"
+    - "govwifi-redirect"
+    - "govwifi-safe-restarter"
+    - "govwifi-shared-frontend"
+    - "govwifi-smoke-tests"
+    - "govwifi-tech-docs"
+    - "govwifi-terraform"
+    - "govwifi-user-signup-api"
+    - "govwifi-watchdog"
 
   channel:
     "#govwifi-monitoring"


### PR DESCRIPTION
# What's changed?
Escape all hypens in the config file

# Why?
The seal hasn't shown up in the team channel for a long time.
In YAML a `-` is a special character to denote list and that could be causing the seal to fail?