### PR TITLE
Disable Octokit auto pagination on API requests

### DIFF
--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -6,9 +6,9 @@ class GithubFetcher
 
   def initialize(team)
     @organisation = ENV["SEAL_ORGANISATION"]
-    @github = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
+    @github = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"], per_page: 10000)
     @github.api_endpoint = ENV["GITHUB_API_ENDPOINT"] if ENV["GITHUB_API_ENDPOINT"]
-    @github.auto_paginate = true
+    @github.auto_paginate = false
     @people = team.members
     @use_labels = team.use_labels
     @exclude_labels = team.exclude_labels.map(&:downcase).uniq

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -124,7 +124,8 @@ RSpec.describe GithubFetcher do
   before do
     allow(Octokit::Client).to receive(:new).and_return(fake_octokit_client)
     allow(fake_octokit_client).to receive_message_chain('user.login')
-    allow(fake_octokit_client).to receive(:auto_paginate=).with(true)
+    allow(fake_octokit_client).to receive(:auto_paginate=).with(false)
+    allow(fake_octokit_client).to receive(:per_page=).with(10000)
     allow(fake_octokit_client).to receive(:search_issues).with("is:pr state:open user:alphagov archived:false -is:draft").and_return(double(items: [pull_2266, pull_2248]))
 
     allow(fake_octokit_client).to receive(:issue_comments).with(whitehall_repo_name, 2266).and_return(comments_2266)

--- a/templates/no_pull_requests.compact.text.erb
+++ b/templates/no_pull_requests.compact.text.erb
@@ -1,0 +1,3 @@
+Aloha team! It's a beautiful day! :happyseal: :happyseal: :happyseal:
+
+No pull requests to review today! :rainbow: :sunny: :metal: :tada:


### PR DESCRIPTION
By default, the `auto_paginate` option in Octokit limits the API response to 100 results per page and makes multiple requests to get all results.

GitHub's API then implements a [secondary rate limit](https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#secondary-rate-limits), preventing us from getting all the results.

Therefore removing the pagination and requesting only a single page so we don't hit the secondary rate limit, with a limit of 10,000 results.  It is unlikely we'll ever have more than 10,000 draft PRs at one time.

Also adds a missing template.