### PR TITLE
Fix up team names

### DIFF
--- a/bin/afternoon_seal.sh
+++ b/bin/afternoon_seal.sh
@@ -3,10 +3,9 @@
 teams=(
   govuk-accounts
   govuk-data-labs
-  govuk-explore-devs
-  govuk-explore-navigation
-  govuk-platform-health
-  govuk-corona-products
+  find-and-view-tech
+  govuk-platform-reliability
+  govuk-corona-services-tech
 )
 
 for team in ${teams[*]} ; do

--- a/bin/afternoon_seal.sh
+++ b/bin/afternoon_seal.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 teams=(
-  govuk-accounts
-  govuk-data-labs
   find-and-view-tech
-  govuk-platform-reliability
+  govuk-accounts
   govuk-corona-services-tech
+  govuk-data-labs
+  govuk-platform-reliability
 )
 
 for team in ${teams[*]} ; do

--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -2,11 +2,11 @@
 
 teams=(
   govuk-accounts-tech
-  govuk-corona-products
+  govuk-corona-services-tech
   govuk-data-labs
-  govuk-explore-devs
+  find-and-view-tech
   govuk-pay
-  govuk-platform-health
+  govuk-platform-reliability
   govuk-publishing
   govwifi
 )

--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 teams=(
+  find-and-view-tech
   govuk-accounts-tech
   govuk-corona-services-tech
   govuk-data-labs
-  find-and-view-tech
   govuk-pay
   govuk-platform-reliability
   govuk-publishing


### PR DESCRIPTION
Remove references to team channels that no longer exist. See commits for details.