### PR TITLE
Teams tidy-up

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -1,14 +1,4 @@
 # Please insert new items alphabetically.
-explore-find-and-view:
-  channel:
-    "#explore-find-and-view"
-
-  quotes:
-    - "Be Excellent To Each Other!"
-    - ":smiling-batman:"
-    - "Don't be working if you're ill!"
-    - ":green_heart:"
-    - "We're not 'working from home', we are _'working at home during a crisis_', so take that time to look after yourselves even during a working day."
 
 find-and-view-tech:
   channel:
@@ -32,6 +22,12 @@ find-and-view-tech:
     - "[PROTOTYPE]"
     - WIP
     - "[WIP]"
+  quotes:
+    - "Be Excellent To Each Other!"
+    - ":smiling-batman:"
+    - "Don't be working if you're ill!"
+    - ":green_heart:"
+    - "We're not 'working from home', we are _'working at home during a crisis_', so take that time to look after yourselves even during a working day."
 
 govuk-accounts:
   channel:
@@ -65,22 +61,7 @@ govuk-accounts-tech:
     - WIP
     - "[WIP]"
 
-govuk-brexit-content-team:
-  members:
-    - benthorner
-    - sihugh
-
-  channel:
-    "#govuk-brexit-content-team"
-
-  compact: true
-
-  exclude_titles:
-    - "[PROTOTYPE]"
-    - WIP
-    - "[WIP]"
-
-govuk-corona-products:
+govuk-corona-services-tech:
   members:
     - gclssvglx
     - GDSNewt
@@ -156,19 +137,15 @@ govuk-datagovuk:
     - WIP
     - "[WIP]"
 
-govuk-platform-health:
+govuk-platform-reliability-team:
   members:
-    - 1pretz1
     - ChrisBAshton
     - deborahchua
-    - hannako
-    - kentsanggds
     - MuriloDalRi
     - nicholsj
-    - Tetrino
 
   channel:
-    "#govuk-platform-health"
+    "#govuk-platform-reliability-team"
 
   exclude_titles:
     - "[DO NOT MERGE]"


### PR DESCRIPTION
This got missed in #273. Fixes up team names / channels, and
removes disbanded teams.

Semi-related Trello: https://trello.com/c/toNMA1Np/2854-fix-seal-and-dependapanda