### PR TITLE
Fix Platform Reliability team name

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -137,7 +137,7 @@ govuk-datagovuk:
     - WIP
     - "[WIP]"
 
-govuk-platform-reliability-team:
+govuk-platform-reliability:
   members:
     - ChrisBAshton
     - deborahchua


### PR DESCRIPTION
This was missed in #273/#275. The team name needs to match what
exists in the morning/afternoon seal config, e.g.
https://github.com/alphagov/seal/blob/ee0c8064accaa0c05b996e50f7616005b9b516c3/bin/afternoon_seal.sh#L8