### PR TITLE
Add Becka Lelew

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -204,6 +204,7 @@ govuk-publishing:
   members:
     - baisa
     - beccapearce
+    - BeckaL
     - benjamineskola
     - brucebolt
     - callumknights


### PR DESCRIPTION
Becka is new to GDS and is a developer in the GOV.UK Publishing Service team.

[Trello card](https://trello.com/c/Hr9FFqgU/180-prepare-to-onboard-becka-lelaw-starting-14-february)