### PR TITLE
Remove me from Coronavirus team

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -66,7 +66,6 @@ govuk-corona-services-tech:
     - gclssvglx
     - GDSNewt
     - JonathanHallam
-    - kevindew
     - leenagupte
     - "Rosa-Fox"
 


### PR DESCRIPTION
This puts me in just a single team (I'm also in Publishing), so this resolves two groups of people getting my PR reminders.