### PR TITLE
Update GOV.UK Publishing Service team

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -220,6 +220,7 @@ govuk-publishing:
   exclude_title:
     - "[DO NOT MERGE]"
     - "WIP"
+    - "[WIP]"
 
   compact: true
 

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -209,6 +209,7 @@ govuk-publishing:
     - brucebolt
     - callumknights
     - DilwoarH
+    - jyoung-gds
     - kevindew
     - ollietreend
     - spikeheap


### PR DESCRIPTION
- Adds a new team member
- Adds `[WIP]` as an ignored title