### PR TITLE
Split govuk-publishing into two teams

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -183,24 +183,35 @@ govuk-pay:
     - "[DRAFT]"
     - WIP
 
-govuk-publishing:
+govuk-publishing-experience:
   members:
     - baisa
     - beccapearce
-    - BeckaL
     - benjamineskola
-    - brucebolt
-    - callumknights
     - davidgisbey
     - davidtrussler
     - DilwoarH
     - jyoung-gds
-    - kevindew
     - ollietreend
-    - spikeheap
 
   channel:
-    "#govuk-publishing-tech"
+    "#govuk-publishing-experience-tech"
+
+  exclude_title:
+    - "[DO NOT MERGE]"
+    - "WIP"
+    - "[WIP]"
+
+  compact: true
+
+govuk-publishing-platform:
+  members:
+    - BeckaL
+    - brucebolt
+    - callumknights
+    - JonathanHallam
+  channel:
+    "#govuk-publishing-platform"
 
   exclude_title:
     - "[DO NOT MERGE]"


### PR DESCRIPTION
Trello: https://trello.com/c/6ij2W9kf/131-split-combined-govuk-publishing-tech-alerts-for-each-team

This sets up the seal alerts for the respective GOV.UK Publishing teams based on their members. 

I've removed myself and Ryan since we span both teams. I'm also using the new name of the govuk-publishing-experience-tech channel which hasn't yet been created.