### PR TITLE
Allow user to add github team

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Seal
+
 [![Build Status](https://travis-ci.org/binaryberry/seal.svg)](https://travis-ci.org/binaryberry/seal)
 
 ## What is it?
 
-This is a Slack bot that publishes a team's pull requests to their Slack Channel, once provided the organisation name and the team members' github names. It is my first 20% project at GDS.
+This is a Slack bot that publishes a team's pull requests to their Slack Channel, once provided the organisation name and either a [Github team] (https://docs.github.com/en/organizations/organizing-members-into-teams/about-teams) name or the team members' individual github names. It is my first 20% project at GDS.
 
 ![image](https://github.com/binaryberry/seal/blob/master/images/readme/informative.png)
 ![image](https://github.com/binaryberry/seal/blob/master/images/readme/angry.png)
@@ -11,9 +12,10 @@ This is a Slack bot that publishes a team's pull requests to their Slack Channel
 ## How to use it?
 
 ### Config
+
 Fork the repo and add/change the config files that relate to your github organisation. For example, the alphagov config file is located at [config/alphagov.yml](config/alphagov.yml) and the config for scheduled daily visits can be found in [bin](bin)
 
-Include your team's name, the Github names of your team members, and the Slack channel you want to post to.
+Include your team's name, the Slack channel you want to post to, and either the name of your team on Github or the the Github names of your individual team members. You can also choose to provide _both_ the Github team name and the names of additional individual team members.
 
 In your shell profile, put in:
 
@@ -39,6 +41,7 @@ export GITHUB_TOKEN="get_your_github_token_from_yourgithub_settings"
 export GITHUB_API_ENDPOINT="your_github_api_endpoint" # OPTIONAL If you are using a Github Enterprise instance
 export SLACK_WEBHOOK="get_your_incoming_webhook_link_for_your_slack_group_channel"
 export SLACK_CHANNEL="#whatever-channel-you-prefer"
+export GITHUB_TEAM="your-team-name-on-github"
 export GITHUB_MEMBERS="netflash,binaryberry,otheruser"
 export GITHUB_USE_LABELS=true
 export GITHUB_EXCLUDE_LABELS="[DO NOT MERGE],Don't merge,DO NOT MERGE,Waiting on factcheck,wip"
@@ -52,6 +55,7 @@ export SEAL_QUOTES="Everyone should have the opportunity to learn. Don’t be af
 - To get a new `SLACK_WEBHOOK`, head to: https://slack.com/services/new/incoming-webhook
 
 ### Bash scripts
+
 In your forked repo, include your team names in the appropriate bash script. Ex. `bin/morning_seal.sh`
 
 ### Local testing
@@ -63,6 +67,7 @@ If you don't want to post github pull requests but a random quote from your team
 ### Slack configuration
 
 You should also set up the following custom emojis in Slack:
+
 - :informative_seal:
 - :angrier_seal:
 - :seal_of_approval:
@@ -81,13 +86,14 @@ When that works, you can push the app to Heroku and add the GITHUB_TOKEN and SLA
 
 Use the Heroku scheduler add-on to create repeated tasks - I set the seal to run at 9.30am every morning (the seal won't post on weekends). The scheduler is at [https://scheduler.heroku.com/dashboard](https://scheduler.heroku.com/dashboard) and the command to run is `bin/seal.rb your_team_name`
 
-Any questions feel free to contact me on Twitter -  my handle is binaryberry
+Any questions feel free to contact me on Twitter - my handle is binaryberry
 
 ## Deploy to Heroku
 
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
 ## How to run the tests?
+
 Just run `rspec` in the command line
 
 ## Docker container
@@ -110,6 +116,7 @@ docker run -it --rm --name seal \
   -e DYNO=${DYNO} \
   -e SLACK_CHANNEL=${SLACK_CHANNEL} \
   -e GITHUB_MEMBERS=${GITHUB_MEMBERS} \
+  -e GITHUB_TEAM=${GITHUB_TEAM} \
   -e GITHUB_USE_LABELS=${GITHUB_USE_LABELS} \
   -e "GITHUB_EXCLUDE_LABELS=${GITHUB_EXCLUDE_LABELS}" \
   -e "SEAL_QUOTES=${SEAL_QUOTES}" \
@@ -119,51 +126,64 @@ docker run -it --rm --name seal \
 ## Diary of how this app was built
 
 10th April:
+
 - Finalised what the app does:
-    - Checks if any pull requests are over 2 days old (angry seal)
-    - at 9.45am prepares an overview of all pull requests that need reviewing (informative seal)
-    - when a team member posts a new pull request, publishes it on slack (notification seal) (this feature was then abandoned, as I thought it's best for this not to be automated, it's more motivating when real people ask for a review, not a bot)
+
+  - Checks if any pull requests are over 2 days old (angry seal)
+  - at 9.45am prepares an overview of all pull requests that need reviewing (informative seal)
+  - when a team member posts a new pull request, publishes it on slack (notification seal) (this feature was then abandoned, as I thought it's best for this not to be automated, it's more motivating when real people ask for a review, not a bot)
 
 - Researched what technologies and gems I could use and what the app structure would be like
 - Started the Rails app
 
 17th April:
+
 - researched github_api
 
 24th April:
+
 - got github_api working, first test with dummy data passing
 
 1st of May
+
 - got github_listener to take into account organisations
 
 8th of May:
+
 - tried stubbing Github API
 
 15th of May:
+
 - Github listener can now return the list of repos of an organisation
 - further attempts to stub GithubAPI using these methods: https://robots.thoughtbot.com/how-to-stub-external-services-in-tests.
 
 21st of May:
+
 - Building Sinatra app for stubbing
 - Attempts to filter the 3,400 repo list by date the repo was modified - tests (and app) are still very slow
 
 28th of May:
+
 - Due to new team structure that assigns a list of repos to each team, decided the manually enter the list of repos that belong to a team instead of scanning through all of them. That should sort the speed problem, the stubbing problem, a lot of things.
 - moved to a non-Rails app to make it lighter
 - got Github to list repos; works for my personal pull requests, but doesn't work with the GOV.UK stuff yet, need to figure out why
 
 5th of June:
+
 - Github fetcher class now works with organisations, hence GOV.UK stuff
 
 11th of June:
+
 - Stubbed Github API
 
 12th of June:
+
 - Github Fetcher now also returns the link to the pull request
 - Started Slackbot poster class, it can post to Slack
 - Started Message builder class, not finished
 
 13th of June:
+
 - finished Slackbot poster class
 - finished Message builder class
 - added name of repo to info sent by GithubFetcher
@@ -171,38 +191,48 @@ docker run -it --rm --name seal \
 - Works locally in test room. YEAY!
 
 17th of June:
+
 - refactoring of Github fetcher
 - pushed to Heroku
 
 18th of June:
+
 - started Heroku scheduler and launched on core-formats team room!
 
 22nd of June
+
 - Ensure Angry seal doesn't get triggered at the weekend
 
 26th of June:
+
 - launched on finding-stuff team
 - investigated adding comments
 
 3rd of July:
+
 - launched on custom team
 - added comments
 - investigating angry seal - stuck by a strange syntax error line 34 when trying to run the script
 
 10th of July
+
 - Extracted config information to yaml files
 - fixed informative seal - mood_hash was causing issues
 
 17th of July
+
 - Angry Seal!
 
 21st of July
+
 - fix API stubbing
 
 22nd of July
+
 - Add age of pull requests
 
 24th of July
+
 - Optionally display labels for a pull request, if they exist (`use_labels` config option)
 - Optionally hide pull requests with certain labels (`exclude_labels` config
   list)
@@ -210,18 +240,22 @@ docker run -it --rm --name seal \
   (`exclude_titles` config list)
 
 19th of August
+
 - Seal will bark at all teams in the config if no team is specified as an
   argument to `./bin/{angry,informative}_seal.rb`, making Heroku scheduling
   easier.
 
 4th of September
+
 - Seal now displays thumbs up when present in comments
 - Angry seal now looks angrier
 
 13th of September
+
 - Seal now has only one script to be triggered - will start either the angry seal, the informative seal or the seal of approval each day.
 
 6th of January
+
 - Seal can now post random quotes from the team's list of quotes in the config. Can be used as a reminder or for inspirational quotes!
 
 ## Tips
@@ -240,12 +274,15 @@ repo_names = response.select { |repo| Date.parse(repo.updated_at.to_s) > (Date.t
 ## CRC
 
 Github fetcher:
+
 - queries Github's API
 
 Message Builder:
+
 - produces message from Github API's content
 
 Slack Poster:
+
 - posts message to Slack
 
 Trello board: https://trello.com/b/sgakJmlY/moody-seal

--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -129,22 +129,24 @@ class GithubFetcher
   end
 
   def get_team_members(team_slug, members)
+    return members if team_slug.nil?
+
     github_team_members = get_github_team_members(team_slug)
     (github_team_members + members).uniq
   end
 
   def get_github_team_members(team_slug)
-    return [] if team_slug.nil? || team_slug.empty?
-    team_members = github.get("/orgs/#{@organisation}/teams/#{team_slug}/members").map{|member| member.login}
+    github.get("/orgs/#{@organisation}/teams/#{team_slug}/members").map { |member| member.login }
   end
 
   def get_team_repos(team_slug, repos)
+    return repos if team_slug.nil?
+
     github_team_repos = get_github_team_repos(team_slug)
     (github_team_repos + repos).uniq
   end
 
   def get_github_team_repos(team_slug)
-    return [] if team_slug.nil? || team_slug.empty?
-    team_repos = github.get("/orgs/#{@organisation}/teams/#{team_slug}/repos").map{|repo| repo.name}
+    github.get("/orgs/#{@organisation}/teams/#{team_slug}/repos").map{|repo| repo.name}
   end
 end

--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -9,19 +9,18 @@ class GithubFetcher
     @github = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
     @github.api_endpoint = ENV["GITHUB_API_ENDPOINT"] if ENV["GITHUB_API_ENDPOINT"]
     @github.auto_paginate = false
-    @people = team.members
+    @github.user.login
+    @people = get_team_members(team.github_team, team.members)
     @use_labels = team.use_labels
     @exclude_labels = team.exclude_labels.map(&:downcase).uniq
     @exclude_titles = team.exclude_titles.map(&:downcase).uniq
     @labels = {}
     @exclude_repos = team.exclude_repos
-    @include_repos = team.include_repos
+    @include_repos = get_team_repos(team.github_team, team.include_repos)
     @sleep_time = ENV.has_key?("THROTTLE_SECS") ? ENV["THROTTLE_SECS"].to_i : 10
   end
 
   def list_pull_requests
-    github.user.login
-
     pull_requests_from_github
       .reject { |pr| hidden?(pr) }
       .map { |pr| present_pull_request(pr) }
@@ -127,5 +126,25 @@ class GithubFetcher
 
   def repo_name(pr)
     pr.html_url.split("/")[4]
+  end
+
+  def get_team_members(team_slug, members)
+    github_team_members = get_github_team_members(team_slug)
+    (github_team_members + members).uniq
+  end
+
+  def get_github_team_members(team_slug)
+    return [] if team_slug.nil? || team_slug.empty?
+    team_members = github.get("/orgs/#{@organisation}/teams/#{team_slug}/members").map{|member| member.login}
+  end
+
+  def get_team_repos(team_slug, repos)
+    github_team_repos = get_github_team_repos(team_slug)
+    (github_team_repos + repos).uniq
+  end
+
+  def get_github_team_repos(team_slug)
+    return [] if team_slug.nil? || team_slug.empty?
+    team_repos = github.get("/orgs/#{@organisation}/teams/#{team_slug}/repos").map{|repo| repo.name}
   end
 end

--- a/lib/team.rb
+++ b/lib/team.rb
@@ -1,6 +1,7 @@
 class Team
   def initialize(
                   members: nil,
+                  github_team: nil,
                   use_labels: nil,
                   compact: nil,
                   exclude_labels: nil,
@@ -11,6 +12,7 @@ class Team
                   slack_channel: nil
                 )
     @members = members || []
+    @github_team  = github_team
     @use_labels = (use_labels.nil? ? false : use_labels)
     @compact = (compact.nil? ? false : compact)
     @exclude_labels = exclude_labels || []
@@ -23,6 +25,7 @@ class Team
 
   attr_reader *%i[
     members
+    github_team
     use_labels
     compact
     exclude_labels

--- a/lib/team_builder.rb
+++ b/lib/team_builder.rb
@@ -39,6 +39,7 @@ class TeamBuilder
   def apply_env(config)
     {
       members: env["GITHUB_MEMBERS"]&.split(",") || config["members"],
+      github_team: env["GITHUB_TEAM"] || config["github_team"],
       use_labels: env["GITHUB_USE_LABELS"] == "true" || config["use_labels"],
       compact: env["COMPACT"] == "true" || config["compact"],
       exclude_labels: env["GITHUB_EXCLUDE_LABELS"]&.split(',') || config["exclude_labels"],

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe GithubFetcher do
   let(:team) {
     Team.new(
       members: team_members_accounts,
+      github_team: github_team,
       use_labels: use_labels,
       exclude_labels: exclude_labels,
       exclude_titles: exclude_titles,
@@ -20,6 +21,7 @@ RSpec.describe GithubFetcher do
   let(:fake_octokit_client) { double(Octokit::Client) }
   let(:whitehall_repo_name) { "#{ENV['SEAL_ORGANISATION']}/whitehall" }
   let(:whitehall_rebuild_repo_name) { "#{ENV['SEAL_ORGANISATION']}/whitehall-rebuild" }
+  let(:whitehall_security_repo_name) { "#{ENV['SEAL_ORGANISATION']}/whitehall-security" }
   let(:blocked_and_wip) do
     [
       {
@@ -71,6 +73,7 @@ RSpec.describe GithubFetcher do
   let(:include_repos) { nil }
 
   let(:team_members_accounts) { %w(binaryberry boffbowsh jackscotti tekin elliotcm tommyp mattbostock) }
+  let(:github_team) { nil }
 
   let(:pull_2266) do
     double(Sawyer::Resource,
@@ -96,6 +99,18 @@ RSpec.describe GithubFetcher do
           )
   end
 
+  let(:pull_2295) do
+    double(Sawyer::Resource,
+           user: double(Sawyer::Resource, login: 'lauramipsum'),
+           title: 'Enable ssh key signing',
+           html_url: 'https://github.com/alphagov/whitehall-security/pull/2295',
+           number: 2295,
+           review_comments: 0,
+           comments: 0,
+           updated_at: '2015-07-17 01:00:44 UTC'
+          )
+  end
+
   let(:comments_2266) do
     [
       "You should add more seal images on the front end",
@@ -111,6 +126,10 @@ RSpec.describe GithubFetcher do
     ].map { |body| double(Sawyer::Resource, body: body)}
   end
 
+  let(:comments_2295) do
+    []
+  end
+
   let(:reviews_2248) do
     [
       double(Sawyer::Resource, state: "APPROVED" )
@@ -119,13 +138,15 @@ RSpec.describe GithubFetcher do
 
   let(:reviews_2266) { [] }
 
+  let(:reviews_2295) { [] }
+
   let(:titles) { github_fetcher.list_pull_requests.map { |pr| pr[:title] } }
 
   before do
     allow(Octokit::Client).to receive(:new).and_return(fake_octokit_client)
     allow(fake_octokit_client).to receive_message_chain('user.login')
     allow(fake_octokit_client).to receive(:auto_paginate=).with(false)
-    response = double(items: [pull_2266, pull_2248])
+    response = double(items: [pull_2266, pull_2248, pull_2295])
     allow(fake_octokit_client).to receive(:search_issues).with("is:pr state:open user:alphagov archived:false -is:draft", per_page: 100).and_return(response)
     allow(fake_octokit_client).to receive(:last_response).and_return(double(data: response, rels: { next: nil }))
 
@@ -134,6 +155,7 @@ RSpec.describe GithubFetcher do
 
     allow(fake_octokit_client).to receive(:pull_request).with(whitehall_rebuild_repo_name, 2248).and_return(pull_2248)
     allow(fake_octokit_client).to receive(:pull_request).with(whitehall_repo_name, 2266).and_return(pull_2266)
+
     allow(fake_octokit_client).to receive(:get).with(%r"repos/alphagov/[\w-]+/pulls/2248/reviews").and_return(reviews_2248)
     allow(fake_octokit_client).to receive(:get).with(%r"repos/alphagov/[\w-]+/pulls/2266/reviews").and_return(reviews_2266)
   end
@@ -172,6 +194,7 @@ RSpec.describe GithubFetcher do
     before do
       allow(fake_octokit_client).to receive(:labels_for_issue).with(whitehall_rebuild_repo_name, 2248).and_return(blocked_and_wip)
       allow(fake_octokit_client).to receive(:labels_for_issue).with(whitehall_repo_name, 2266).and_return([])
+      allow(fake_octokit_client).to receive(:labels_for_issue).with(whitehall_security_repo_name, 2295).and_return([])
     end
 
     context 'excluding nothing' do
@@ -258,6 +281,65 @@ RSpec.describe GithubFetcher do
         it 'filters out PRs for the "whitehall-rebuild" repo' do
           expect(titles).to match_array(['[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host'])
         end
+      end
+    end
+  end
+
+  context 'with github team configured' do
+
+    let(:use_labels) { false }
+    let(:github_team) { 'whitehall-security-devs' }
+
+    let(:github_team_members) do
+      [
+        double(Sawyer::Resource, login: "lauramipsum" )
+      ]
+    end
+
+    let(:github_team_repos) do
+      [
+        double(Sawyer::Resource, name: "whitehall-security" )
+      ]
+    end
+
+    before do
+      allow(fake_octokit_client).to receive(:get).with("/orgs/#{ENV['SEAL_ORGANISATION']}/teams/#{github_team}/members").and_return(github_team_members)
+      allow(fake_octokit_client).to receive(:get).with("/orgs/#{ENV['SEAL_ORGANISATION']}/teams/#{github_team}/repos").and_return(github_team_repos)
+      allow(fake_octokit_client).to receive(:issue_comments).with(whitehall_security_repo_name, 2295).and_return(comments_2295)
+      allow(fake_octokit_client).to receive(:pull_request).with(whitehall_security_repo_name, 2295).and_return(pull_2295)
+      allow(fake_octokit_client).to receive(:get).with(%r"repos/alphagov/[\w-]+/pulls/2295/reviews").and_return(reviews_2295)
+    end
+
+    context 'with no team members configured' do
+      let(:include_repos) { ['whitehall', 'whitehall-rebuild', 'whitehall-security'] }
+      let(:team_members_accounts) { [] }
+
+      it 'only shows PRs for members of the github team' do
+        expect(titles).to match_array(["Enable ssh key signing"])
+      end
+    end
+     
+    context 'with additional team members configured' do
+      let(:include_repos) { ['whitehall', 'whitehall-rebuild', 'whitehall-security'] }
+
+      it 'shows PRs for members of the github team and the additional team members' do
+        expect(titles).to match_array(["Enable ssh key signing","Remove all Import-related code","[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host"])
+      end
+    end
+     
+    context 'without include_repos configured' do
+      let(:include_repos) { [] }
+
+      it 'only shows PRs for repos owned by the github team' do
+        expect(titles).to match_array(["Enable ssh key signing"])
+      end
+    end
+     
+    context 'with include_repos configured' do
+      let(:include_repos) { ['whitehall', 'whitehall-rebuild'] }
+
+      it 'shows PRs for repos owned by the github team and the additional configured repos' do
+        expect(titles).to match_array(["Enable ssh key signing","Remove all Import-related code","[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host"])
       end
     end
   end

--- a/spec/team_builder_spec.rb
+++ b/spec/team_builder_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe TeamBuilder do
         ],
         "channel" => "#tigers",
       },
+      "cats" => {
+        "github_team" => "cat-coding-club",
+        "channel" => "#cats",
+      },
     ))
   end
 
@@ -48,12 +52,13 @@ RSpec.describe TeamBuilder do
   let(:teams) { TeamBuilder.build(env: env) }
 
   it "loads each team from the static config file" do
-    expect(teams.count).to eq(2)
-    expect(teams.map(&:channel)).to match_array(["#lions", "#tigers"])
+    expect(teams.count).to eq(3)
+    expect(teams.map(&:channel)).to match_array(["#lions", "#tigers", "#cats"])
   end
 
   it "loads all keys" do
     lions = teams.find {|t| t.channel == "#lions"}
+    cats = teams.find {|t| t.channel == "#cats"}
 
     expect(lions.members).to eq([
       "lil lion",
@@ -78,6 +83,8 @@ RSpec.describe TeamBuilder do
       "This is a quote",
       "This is also a quote",
     ])
+
+    expect(cats.github_team).to eq("cat-coding-club")
   end
 
   it "provides sensible defaults" do


### PR DESCRIPTION
Closes #226 
This allows the user to add a github team in addition to or instead of the existing members and include_repos settings.

I'm planning to follow this up later with a PR adding the forms team to the config, which should make it a bit clearer how this works, but also hoping my documentation changes here are clear enough.