### PR TITLE
Increase time between API calls

### DIFF
--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -16,7 +16,7 @@ class GithubFetcher
     @labels = {}
     @exclude_repos = team.exclude_repos
     @include_repos = team.include_repos
-    @sleep_time = ENV.has_key?("THROTTLE_SECS") ? ENV["THROTTLE_SECS"].to_i : 10
+    @sleep_time = ENV.has_key?("THROTTLE_SECS") ? ENV["THROTTLE_SECS"].to_i : 60
   end
 
   def list_pull_requests


### PR DESCRIPTION
The time between API calls is too short and that will trigger the secondary rate-limiting.

https://trello.com/c/eOpATt3M/2926-investigate-problems-with-the-seal