### PR TITLE
Add GOV.UK Forms team

### DIFF
--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -5,6 +5,7 @@ teams=(
   govuk-accounts-tech
   govuk-corona-services-tech
   govuk-data-labs
+  govuk-forms
   govuk-pay
   govuk-platform-reliability
   govuk-publishing

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -192,6 +192,20 @@ govuk-datagovuk:
     - WIP
     - "[WIP]"
 
+govuk-forms:
+  github_team: "forms-devs"
+
+  channel:
+    "#govuk-forms-tech"
+
+  exclude_titles:
+    - "[DO NOT MERGE]"
+    - "[PROTOTYPE]"
+    - WIP
+    - "[WIP]"
+
+  compact: true
+
 govuk-platform-reliability:
   members:
     - catalinailie


### PR DESCRIPTION
This adds the GOV.UK Forms developers' Github team to the alphagov config.