### PR TITLE
Finish and enable config for GOV.UK Replatforming team.

### DIFF
--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -9,6 +9,7 @@ teams=(
   govuk-pay
   govuk-platform-reliability
   govuk-publishing
+  govuk-replatforming
   govwifi
 )
 

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -313,26 +313,19 @@ govuk-publishing-platform:
   compact: true
 
 govuk-replatforming:
-  members:
-    - richardTowers
-    - sengi
-    - alexbakervr
-    - lwilts
-    - marcpomfret
-    - theseanything
-    - jibolaolu
-    - fredericfrancois
-    - rtrinque
-    - smford
-    - nsabri1
-
-  channel:
-    "#govuk-replatforming"
-
+  github_team: gov-uk-replatforming
+  channel: "#govuk-replatforming"
+  compact: true
   exclude_titles:
+    - "[DNM]"
     - "[DO NOT MERGE]"
-    - WIP
     - "[WIP]"
+    - "WIP "
+    - "WIP:"
+  include_repos:
+    - govuk-helm-charts
+    - govuk-infrastructure
+    - govuk-kubernetes-cluster-user-docs
 
 govwifi:
   members:


### PR DESCRIPTION
We'll maintain the team membership list [in GitHub](https://github.com/orgs/alphagov/teams/gov-uk-replatforming) rather than in this file.

Not enabling the [fortune](https://en.wikipedia.org/wiki/Fortune_(Unix)) feature yet — we'll see how we go with the other features to begin with.