### PR TITLE
Correct publishing team in morning seal

### DIFF
--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -8,7 +8,8 @@ teams=(
   govuk-forms
   govuk-pay
   govuk-platform-reliability
-  govuk-publishing
+  govuk-publishing-experience
+  govuk-publishing-platform  
   govuk-replatforming
   govwifi
 )


### PR DESCRIPTION
These haven't been working as the govuk-publishing team no longer exists and we now have two distinct teams.