### PR TITLE
Add Data Services teams

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -137,47 +137,70 @@ govuk-accounts-tech:
     - WIP
     - "[WIP]"
 
-govuk-data-labs:
-  members:
-    - ESKYoung
-    - exfalsoquodlibet
-    - mammykins
-    - maxf
-    - nacnudus
-    - "st-alice"
-    - ZacharyForrest
-    - zilnhoj
-
+data-infrastructure:
   channel:
-    "#govuk-data-labs"
-
+    "#data-infrastructure"
+  members:
+    - andyhd
+    - DAVadgama
+    - Nyzl
+    - ollyroberts
+    - "st-alice"
+    - zilnhoj
   exclude_titles:
     - "[DO NOT MERGE]"
     - "[PROTOTYPE]"
     - WIP
     - "[WIP]"
-
   use_labels: true
-
   exclude_labels:
     - "wip"
     - "WIP"
     - "ignore"
 
-  quotes:
-    - "Be Excellent To Each Other!"
-    - ":smiling-batman:"
-    - "Don't be working if you're ill!"
-    - ":green_heart:"
-    - "Remember to take into consideration that our colleagues may be having a hard time outside of work. Support them at a team and individual level."
-    - "Remember to avoid talking over each other during meetings, and be mindful of colleagues who wish to speak but have yet to do so."
-    - "Understand the diverse character types within our team and appreciate that some of us may prefer a description of a meeting in advance to allow time to prepare."
-    - "Keep conversations inclusive to the audience, ensuring that technical detail is fairly high level where possible."
-    - "Be mindful of the workload of others even if it does not impact yours directly."
-    - "Clarify the importance of attendance in certain meetings, outlining the purpose/objective, and where appropriate an agenda that helps us get to said outcome."
-    - "Give informal and continuous feedback especially if the feedback includes encouragement."
-    - "We're not 'working from home', we are _'working at home during a crisis_', so we need to take the time that we need during a working day."
+data-insights:
+  channel:
+    "#data-insights"
+  members:
+    - DMorrison1996
+    - hwrightson
+    - j-marvin-GDS
+    - paulcronk
+    - TMSGDS
+  exclude_titles:
+    - "[DO NOT MERGE]"
+    - "[PROTOTYPE]"
+    - WIP
+    - "[WIP]"
+  use_labels: true
+  exclude_labels:
+    - "wip"
+    - "WIP"
+    - "ignore"
 
+data-products:
+  channel:
+    "#data-products"
+  members:
+    - abdisalam101
+    - amyrosecastiglione
+    - exfalsoquodlibet
+    - FelixReillyGDS
+    - mammykins
+    - maxf
+    - nacnudus
+    - rory-hurley-gds
+    - "st-alice"
+  exclude_titles:
+    - "[DO NOT MERGE]"
+    - "[PROTOTYPE]"
+    - WIP
+    - "[WIP]"
+  use_labels: true
+  exclude_labels:
+    - "wip"
+    - "WIP"
+    - "ignore"
 
 govuk-datagovuk:
   members:


### PR DESCRIPTION
GOV.UK Data Labs no longer exists, and that team and the other Data teams have
renamed their Slack channels.

This commit replaces the config for the now-defunct govuk-data-labs team with
that of the current Data Services teams: Data Infrastructure, Data Insights and
Data Products.