### PR TITLE
Post via team repo ownership rather than who raised PR

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,17 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+
+inherit_mode:
+  merge:
+    - Exclude
+
+# **************************************************************
+# TRY NOT TO ADD OVERRIDES IN THIS FILE
+#
+# This repo is configured to follow the RuboCop GOV.UK styleguide.
+# Any rules you override here will cause this repo to diverge from
+# the way we write code in all other GOV.UK repos.
+#
+# See https://github.com/alphagov/rubocop-govuk/blob/main/CONTRIBUTING.md
+# **************************************************************

--- a/Gemfile
+++ b/Gemfile
@@ -1,17 +1,18 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 ruby File.read(".ruby-version").chomp
 
-gem 'slack-poster', '~> 1.0.1'
 gem "octokit", "~> 5.6"
+gem "rubocop-govuk", require: false
 gem "sinatra"
+gem "slack-poster", "~> 1.0.1"
 gem "thin"
 
 group :test do
-  gem 'jsonlint'
-  gem 'rake'
-  gem 'rspec'
-  gem 'timecop'
-  gem 'pry-byebug'
   gem "fakefs"
+  gem "jsonlint"
+  gem "pry-byebug"
+  gem "rake"
+  gem "rspec"
+  gem "timecop"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (7.0.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
+    ast (2.4.2)
     byebug (11.1.3)
     coderay (1.1.3)
+    concurrent-ruby (1.1.10)
     daemons (1.4.1)
     diff-lcs (1.5.0)
     eventmachine (1.2.7)
@@ -16,6 +23,9 @@ GEM
     httparty (0.16.4)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
+    json (2.6.2)
     jsonlint (0.3.0)
       oj (~> 3)
       optimist (~> 3)
@@ -23,6 +33,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
+    minitest (5.16.3)
     multi_xml (0.6.0)
     mustermann (2.0.2)
       ruby2_keywords (~> 0.0.1)
@@ -31,6 +42,9 @@ GEM
       sawyer (~> 0.9)
     oj (3.13.21)
     optimist (3.0.1)
+    parallel (1.22.1)
+    parser (3.1.2.1)
+      ast (~> 2.4.1)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -41,7 +55,10 @@ GEM
     rack (2.2.4)
     rack-protection (2.2.2)
       rack
+    rainbow (3.1.1)
     rake (13.0.6)
+    regexp_parser (2.5.0)
+    rexml (3.2.5)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -55,6 +72,33 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
+    rubocop (1.35.0)
+      json (~> 2.3)
+      parallel (~> 1.10)
+      parser (>= 3.1.2.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.20.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.21.0)
+      parser (>= 3.1.1.0)
+    rubocop-govuk (4.7.0)
+      rubocop (= 1.35.0)
+      rubocop-ast (= 1.21.0)
+      rubocop-rails (= 2.15.2)
+      rubocop-rake (= 0.6.0)
+      rubocop-rspec (= 2.12.1)
+    rubocop-rails (2.15.2)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.7.0, < 2.0)
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
+    rubocop-rspec (2.12.1)
+      rubocop (~> 1.31)
+    ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
@@ -72,6 +116,9 @@ GEM
       rack (>= 1, < 3)
     tilt (2.0.11)
     timecop (0.9.5)
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.3.0)
 
 PLATFORMS
   ruby
@@ -83,6 +130,7 @@ DEPENDENCIES
   pry-byebug
   rake
   rspec
+  rubocop-govuk
   sinatra
   slack-poster (~> 1.0.1)
   thin

--- a/LICENCE
+++ b/LICENCE
@@ -1,4 +1,5 @@
-Copyright (C) 2015 Tatiana Soukiassian
+The MIT License (MIT)
+Copyright (C) 2011 Crown copyright (Government Digital Service)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ export SLACK_CHANNEL="#whatever-channel-you-prefer"
 export GITHUB_TEAM="your-team-name-on-github"
 export GITHUB_USE_LABELS=true
 export GITHUB_EXCLUDE_LABELS="[DO NOT MERGE],Don't merge,DO NOT MERGE,Waiting on factcheck,wip"
-export GITHUB_EXCLUDE_REPOS="notmyproject,someotherproject" # Ensure these projects are *NOT* included
-export GITHUB_INCLUDE_REPOS="definitelymyproject,forsuremyproject" # Ensure *only* these projects will be included
+export GITHUB_REPOS="myapp,anotherrepo" # Repos you want to be notified about
 export COMPACT=true # Use a more compact version of the seal output
 export SEAL_QUOTES="Everyone should have the opportunity to learn. Don’t be afraid to pick up stories on things you don’t understand and ask for help with them.,Try to pair when possible."
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## What is it?
 
-This is a Slack bot that publishes a team's pull requests to their Slack Channel, once provided the organisation name, team names and respectivo repos.
+This is a Slack bot that publishes a team's pull requests to their Slack Channel, once provided the organisation name, team names and respective repos.
 
 ![image](https://github.com/binaryberry/seal/blob/master/images/readme/informative.png)
 ![image](https://github.com/binaryberry/seal/blob/master/images/readme/angry.png)
@@ -84,9 +84,9 @@ Use the Heroku scheduler add-on to create repeated tasks - I set the seal to run
 
 Any questions feel free to contact me on Twitter - my handle is binaryberry
 
-## Deploy to Heroku
+## Deployment
 
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+Heroku will deploy the main branch automatically.
 
 ## How to run the tests?
 
@@ -131,22 +131,6 @@ response = github.repos(org: ENV['SEAL_ORGANISATION'])
 repo_names = response.select { |repo| Date.parse(repo.updated_at.to_s) > (Date.today - 365) }.map(&:name)
 ```
 
-## CRC
+## Licence
 
-Github fetcher:
-
-- queries Github's API
-
-Message Builder:
-
-- produces message from Github API's content
-
-Slack Poster:
-
-- posts message to Slack
-
-Trello board: https://trello.com/b/sgakJmlY/moody-seal
-
-## License
-
-See the [LICENSE](LICENSE) file for license rights and limitations (MIT).
+[MIT License](LICENCE)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # Seal
 
-[![Build Status](https://travis-ci.org/binaryberry/seal.svg)](https://travis-ci.org/binaryberry/seal)
-
 ## What is it?
 
-This is a Slack bot that publishes a team's pull requests to their Slack Channel, once provided the organisation name and either a [Github team] (https://docs.github.com/en/organizations/organizing-members-into-teams/about-teams) name or the team members' individual github names. It is my first 20% project at GDS.
+This is a Slack bot that publishes a team's pull requests to their Slack Channel, once provided the organisation name, team names and respectivo repos.
 
 ![image](https://github.com/binaryberry/seal/blob/master/images/readme/informative.png)
 ![image](https://github.com/binaryberry/seal/blob/master/images/readme/angry.png)
@@ -15,7 +13,7 @@ This is a Slack bot that publishes a team's pull requests to their Slack Channel
 
 Fork the repo and add/change the config files that relate to your github organisation. For example, the alphagov config file is located at [config/alphagov.yml](config/alphagov.yml) and the config for scheduled daily visits can be found in [bin](bin)
 
-Include your team's name, the Slack channel you want to post to, and either the name of your team on Github or the the Github names of your individual team members. You can also choose to provide _both_ the Github team name and the names of additional individual team members.
+Include your team's name, repos and the Slack channel you want to post to.
 
 In your shell profile, put in:
 
@@ -42,7 +40,6 @@ export GITHUB_API_ENDPOINT="your_github_api_endpoint" # OPTIONAL If you are usin
 export SLACK_WEBHOOK="get_your_incoming_webhook_link_for_your_slack_group_channel"
 export SLACK_CHANNEL="#whatever-channel-you-prefer"
 export GITHUB_TEAM="your-team-name-on-github"
-export GITHUB_MEMBERS="netflash,binaryberry,otheruser"
 export GITHUB_USE_LABELS=true
 export GITHUB_EXCLUDE_LABELS="[DO NOT MERGE],Don't merge,DO NOT MERGE,Waiting on factcheck,wip"
 export GITHUB_EXCLUDE_REPOS="notmyproject,someotherproject" # Ensure these projects are *NOT* included
@@ -115,7 +112,6 @@ docker run -it --rm --name seal \
   -e SLACK_WEBHOOK=${SLACK_WEBHOOK} \
   -e DYNO=${DYNO} \
   -e SLACK_CHANNEL=${SLACK_CHANNEL} \
-  -e GITHUB_MEMBERS=${GITHUB_MEMBERS} \
   -e GITHUB_TEAM=${GITHUB_TEAM} \
   -e GITHUB_USE_LABELS=${GITHUB_USE_LABELS} \
   -e "GITHUB_EXCLUDE_LABELS=${GITHUB_EXCLUDE_LABELS}" \

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 begin
-  require 'rspec/core/rake_task'
+  require "rspec/core/rake_task"
 
   RSpec::Core::RakeTask.new(:spec)
 rescue LoadError
@@ -7,17 +7,17 @@ rescue LoadError
 end
 
 begin
-  require 'jsonlint/rake_task'
+  require "jsonlint/rake_task"
   JsonLint::RakeTask.new do |t|
-    t.paths = %w(
-    *.json
-    )
+    t.paths = %w[
+      *.json
+    ]
   end
 rescue LoadError
   # no jsonlint available
 end
 
-task :default => [
-  :jsonlint,
-  :spec,
+task default: %i[
+  jsonlint
+  spec
 ]

--- a/app.json
+++ b/app.json
@@ -16,10 +16,6 @@
     "GITHUB_API_ENDPOINT": {
       "description": "OPTIONAL. If you are using a Github Enterprise instance instead of public github.com i.e https://github.yourcompany.com/api/v3"
     },
-    "GITHUB_MEMBERS": {
-      "description": "Comma separated list of github members",
-      "required": false
-    },
     "GITHUB_USE_LABELS": {
       "description": "Comma separated list of labels to include",
       "required": false

--- a/bin/afternoon_seal.sh
+++ b/bin/afternoon_seal.sh
@@ -3,8 +3,6 @@
 teams=(
   find-and-view-tech
   govuk-accounts
-  govuk-corona-services-tech
-  govuk-data-labs
   govuk-platform-reliability
 )
 

--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -3,9 +3,10 @@
 teams=(
   find-and-view-tech
   govuk-accounts-tech
-  govuk-corona-services-tech
-  govuk-data-labs
+  govuk-datagovuk
+  govuk-developers
   govuk-forms
+  govuk-frontenders
   govuk-pay
   govuk-platform-reliability
   govuk-publishing-experience
@@ -21,7 +22,6 @@ done
 morning_quote_teams=(
   fun-workstream-govuk
   fun-workstream-gds-community
-  fun-workstream-test-channel
   govuk-green-team
 )
 

--- a/bin/seal.rb
+++ b/bin/seal.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
-require_relative "../lib/seal"
-require_relative "../lib/team_builder"
+require_relative '../lib/seal'
+require_relative '../lib/team_builder'
 
 teams = TeamBuilder.build(env: ENV, team_name: ARGV[0])
 Seal.new(teams).bark(mode: ARGV[1])

--- a/config.ru
+++ b/config.ru
@@ -1,2 +1,4 @@
-require './server.rb'
+# frozen_string_literal: true
+
+require './server'
 run SealApp

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -3,23 +3,6 @@
 find-and-view-tech:
   channel:
     "#find-and-view-tech"
-  members:
-    - "1pretz1"
-    - AgaDufrat
-    - andyhd
-    - "chao-xian"
-    - "chris-gds"
-    - edwardkerry
-    - hannako
-    - hannalaakso
-    - "jon-kirwan"
-    - "KludgeKML"
-    - kashifatcha
-    - martinjjones
-    - matthillco
-    - maxgds
-    - patrickpatrickpatrick
-    - Tetrino
   compact: true
   exclude_titles:
     - "[DO NOT MERGE]"
@@ -136,11 +119,6 @@ govuk-accounts:
     - "We invest time and effort in increasing our understanding of the problems we’re working on. This will help us make things better for users and move the conversation about personalisation in government forward."
 
 govuk-accounts-tech:
-  members:
-    - alex9smith
-    - danacotoran
-    - huwd
-
   channel:
     "#govuk-accounts-tech"
 
@@ -153,13 +131,6 @@ govuk-accounts-tech:
 data-infrastructure:
   channel:
     "#data-infrastructure"
-  members:
-    - andyhd
-    - DAVadgama
-    - Nyzl
-    - ollyroberts
-    - "st-alice"
-    - zilnhoj
   exclude_titles:
     - "[DO NOT MERGE]"
     - "[PROTOTYPE]"
@@ -174,12 +145,6 @@ data-infrastructure:
 data-insights:
   channel:
     "#data-insights"
-  members:
-    - DMorrison1996
-    - hwrightson
-    - j-marvin-GDS
-    - paulcronk
-    - TMSGDS
   exclude_titles:
     - "[DO NOT MERGE]"
     - "[PROTOTYPE]"
@@ -194,16 +159,6 @@ data-insights:
 data-products:
   channel:
     "#data-products"
-  members:
-    - abdisalam101
-    - amyrosecastiglione
-    - exfalsoquodlibet
-    - FelixReillyGDS
-    - mammykins
-    - maxf
-    - nacnudus
-    - rory-hurley-gds
-    - "st-alice"
   exclude_titles:
     - "[DO NOT MERGE]"
     - "[PROTOTYPE]"
@@ -216,9 +171,6 @@ data-products:
     - "ignore"
 
 govuk-datagovuk:
-  members:
-    - kentsanggds
-
   channel:
     "#govuk-datagovuk"
 
@@ -243,18 +195,6 @@ govuk-forms:
   compact: true
 
 govuk-platform-reliability:
-  members:
-    - catalinailie
-    - ChrisBAshton
-    - deborahchua
-    - MahmudH
-    - MuriloDalRi
-    - PeterHattyar
-    - nicholsj
-    - robinjam
-    - rtrinque
-    - sihugh
-
   channel:
     "#govuk-platform-reliability-team"
 
@@ -277,33 +217,6 @@ govuk-platform-reliability:
   compact: true
 
 govuk-pay:
-  members:
-    - AbdirizakIdris
-    - alanmaddrell
-    - alan-gds
-    - alexbishop1
-    - antoniasimmons
-    - Beth-Brown
-    - heathd
-    - iqbalgds
-    - jabrahoarder
-    - jfharden
-    - "jonny-walkley"
-    - katstevens
-    - kaydale
-    - kbottla
-    - Nadia42
-    - nlsteers
-    - niaaudrina
-    - oswaldquek
-    - richblake
-    - Rkotyank
-    - SandorArpa
-    - sfount
-    - stephencdaly
-    - "xander-gds"
-    - sjzarb
-
   channel:
     "#govuk-pay-tech"
 
@@ -313,17 +226,6 @@ govuk-pay:
     - WIP
 
 govuk-publishing-experience:
-  members:
-    - baisa
-    - beccapearce
-    - benjamineskola
-    - dnkrj
-    - davidgisbey
-    - davidtrussler
-    - DilwoarH
-    - jyoung-gds
-    - ollietreend
-
   channel:
     "#govuk-publishing-experience-tech"
 
@@ -335,11 +237,6 @@ govuk-publishing-experience:
   compact: true
 
 govuk-publishing-platform:
-  members:
-    - BeckaL
-    - brucebolt
-    - callumknights
-    - JonathanHallam
   channel:
     "#govuk-publishing-platform"
 
@@ -366,15 +263,6 @@ govuk-replatforming:
     - govuk-kubernetes-cluster-user-docs
 
 govwifi:
-  members:
-    - koetsier
-    - camdesgov
-    - sarahseewhy
-    - "seb-szy"
-    - cbaines
-    - szd55gds
-    - jimnarey
-
   include_repos:
     - "govwifi-acceptance-tests"
     - "govwifi-admin"

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -1,29 +1,83 @@
-# Please insert new items alphabetically.
+---
+data-infrastructure:
+  channel: '#data-infrastructure'
+  exclude_labels:
+    - WIP
+    - ignore
+  exclude_titles:
+    - DO NOT MERGE
+    - PROTOTYPE
+    - WIP
+  use_labels: true
+
+data-insights:
+  channel: '#data-insights'
+  exclude_labels:
+    - WIP
+    - ignore
+  exclude_titles:
+    - DO NOT MERGE
+    - PROTOTYPE
+    - WIP
+  use_labels: true
+
+data-products:
+  channel: '#data-products'
+  exclude_labels:
+    - WIP
+    - ignore
+  exclude_titles:
+    - DO NOT MERGE
+    - PROTOTYPE
+    - WIP
+  repos:
+    - data-community-tech-docs
+    - differential-privacy-tests
+    - govuk-accessibility-reports
+    - govuk-content-metadata
+    - govuk-content-similarity
+    - govuk-data-science-workshop
+    - govuk-datalabs-streamlit-NER
+    - govuk-entity-personalisation
+    - govuk-feedback-pipeline
+    - govuk-feedback-spam-classifier
+    - govuk-intent-detector
+    - govuk-knowledge-graph
+    - govuk-mongodb-content
+    - govuk-network-data
+    - govuk-networks
+    - govuk-networkx-tutorial
+    - govuk-related-links-recommender
+    - govuk-spaCy
+    - govuk-user-feedback-processing
+    - govuk-user-journey-analysis-tools
+    - govuk-user-journey-models
+    - govuk-wuj-network-analysis
+    - govuk_ab_analysis
+    - insights-data-visualisation-templates
+    - lstm_segmentation
+    - related-links-data
+    - tagging-suggester
+  use_labels: true
 
 find-and-view-tech:
-  channel:
-    "#find-and-view-tech"
+  channel: '#find-and-view-tech'
   compact: true
   exclude_titles:
-    - "[DO NOT MERGE]"
-    - "[PROTOTYPE]"
+    - DNM
+    - DO NOT MERGE
+    - DRAFT
+    - PARKED
+    - PROTOTYPE
     - WIP
-    - "[WIP]"
   quotes:
-    - "Be Excellent To Each Other!"
-    - ":smiling-batman:"
-    - "Don't be working if you're ill!"
-    - ":green_heart:"
-
-# fun-workstream-test-channel:
-#   channel:
-#     "#sealtesting"
-#   quotes:
-#     - <https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/this-is-gds/its-ok-to|It's okay to> test the seal! (No quotes)
+    - Be Excellent To Each Other!
+    - ':smiling-batman:'
+    - Don't be working if you're ill!
+    - ':green_heart:'
 
 fun-workstream-gds-community:
-  channel:
-    "#gds-community"
+  channel: '#gds-community'
   quotes:
     - <https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/this-is-gds/its-ok-to|It's ok to> feel the way you feel
     - <https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/this-is-gds/its-ok-to|It's ok to> talk about how you're feeling
@@ -56,8 +110,7 @@ fun-workstream-gds-community:
     - <https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/this-is-gds/its-ok-to|It's ok to> love what you do
 
 fun-workstream-govuk:
-  channel:
-    "#govuk"
+  channel: '#govuk'
   quotes:
     - <https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/this-is-gds/its-ok-to|It's ok to> feel the way you feel
     - <https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/this-is-gds/its-ok-to|It's ok to> talk about how you're feeling
@@ -89,119 +142,123 @@ fun-workstream-govuk:
     - <https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/this-is-gds/its-ok-to|It's ok to> put yourself first
     - <https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/this-is-gds/its-ok-to|It's ok to> love what you do
 
-govuk-green-team:
-  channel:
-    "#govuk-green-team"
-  quotes:
-    - "Remember to make time for personal development :big-brain:"
-    - "Remember to make time for community and corporate objectives :handshake:"
-    - "Remember to make time for wellbeing :happyseal:"
-    - "Remember to celebrating maintaining content :celebrate:"
-    - "Remember to fill out the <https://docs.google.com/spreadsheets/d/1MV7ASHzDj_FWxix2tCo_EpuBmK0uvuYPnwjijjGIp00/edit#gid=0|spreadsheet> if you're going into the office soon so your teammates can look out for you. :office:"
-    - "Remember to add <https://docs.google.com/document/d/14L5FbIxpTEcjTXgA2deTAupr4y8n3JcIJixNSH5Czz0/edit|QOTDs> to the pinned list when you think of them"
-    - "Remember to read or add entries to the monthly newsletter (pinned to the channel) and find out what the team has been doing lately! :newspaper:"
-    - "Remember to <https://forms.gle/DdzRiptNuYQqA1Xn9|let me know> if there’s anything else I can help with or if you have any feedback. :mega:"
-
 govuk-accounts:
-  channel:
-    "#govuk-accounts"
-
+  channel: '#govuk-accounts'
   quotes:
-    - "We put users first. We strive to create services that bring real value to our users and that meet their needs and expectations."
-    - "We believe users should feel safe and confident when they use our services."
-    - "We design for everyone. We think about under-represented audiences from the start and check our biases throughout the design process."
-    - "We’re comfortable challenging assumptions and asking difficult questions. We speak truth to power."
-    - "We’re OK with change, failure, ambiguity, and adapting our approach."
-    - "We work collaboratively. Our work does not happen in discipline silos and we value the contributions of every discipline equally."
-    - "We treat each other with integrity, honesty and respect."
-    - "We work in the open so users and government colleagues know what we’re doing and why."
-    - "We know we can't do this alone. We need to work with teams across GDS and government to succeed."
-    - "We invest time and effort in increasing our understanding of the problems we’re working on. This will help us make things better for users and move the conversation about personalisation in government forward."
+    - We put users first. We strive to create services that bring real value to our users and that meet their needs and expectations.
+    - We believe users should feel safe and confident when they use our services.
+    - We design for everyone. We think about under-represented audiences from the start and check our biases throughout the design process.
+    - We’re comfortable challenging assumptions and asking difficult questions. We speak truth to power.
+    - We’re OK with change, failure, ambiguity, and adapting our approach.
+    - We work collaboratively. Our work does not happen in discipline silos and we value the contributions of every discipline equally.
+    - We treat each other with integrity, honesty and respect.
+    - We work in the open so users and government colleagues know what we’re doing and why.
+    - We know we can't do this alone. We need to work with teams across GDS and government to succeed.
+    - We invest time and effort in increasing our understanding of the problems we’re working on. This will help us make things better for users and move the conversation about personalisation in government forward.
 
 govuk-accounts-tech:
-  channel:
-    "#govuk-accounts-tech"
-
+  channel: '#govuk-accounts-tech'
   exclude_titles:
-    - "[DO NOT MERGE]"
-    - "[PROTOTYPE]"
+    - DNM
+    - DO NOT MERGE
+    - DRAFT
+    - PARKED
+    - PROTOTYPE
     - WIP
-    - "[WIP]"
-
-data-infrastructure:
-  channel:
-    "#data-infrastructure"
-  exclude_titles:
-    - "[DO NOT MERGE]"
-    - "[PROTOTYPE]"
-    - WIP
-    - "[WIP]"
-  use_labels: true
-  exclude_labels:
-    - "wip"
-    - "WIP"
-    - "ignore"
-
-data-insights:
-  channel:
-    "#data-insights"
-  exclude_titles:
-    - "[DO NOT MERGE]"
-    - "[PROTOTYPE]"
-    - WIP
-    - "[WIP]"
-  use_labels: true
-  exclude_labels:
-    - "wip"
-    - "WIP"
-    - "ignore"
-
-data-products:
-  channel:
-    "#data-products"
-  exclude_titles:
-    - "[DO NOT MERGE]"
-    - "[PROTOTYPE]"
-    - WIP
-    - "[WIP]"
-  use_labels: true
-  exclude_labels:
-    - "wip"
-    - "WIP"
-    - "ignore"
 
 govuk-datagovuk:
-  channel:
-    "#govuk-datagovuk"
-
+  channel: '#govuk-datagovuk'
   exclude_titles:
-    - "[DO NOT MERGE]"
-    - "[PROTOTYPE]"
+    - DNM
+    - DO NOT MERGE
+    - DRAFT
+    - PARKED
+    - PROTOTYPE
     - WIP
-    - "[WIP]"
+  repos:
+    - ckan-functional-tests
+    - ckan-mock-harvest-sources
+    - ckanext-datagovuk
+    - datagovuk-tech-docs
+    - datagovuk_find
+    - datagovuk_publish
+    - datagovuk_publish_elasticsearch_monitor
+    - datagovuk_reference
+
+govuk-developers:
+  channel: '#govuk-developers'
+  exclude_titles:
+    - DNM
+    - DO NOT MERGE
+    - DRAFT
+    - PARKED
+    - PROTOTYPE
+    - WIP
+  repos:
+    - govuk-browser-extension
+    - govuk-connect
+    - govuk-developer-docs
+    - govuk-docker
+    - govuk-ithc-documentation
+    - govuk-rfcs
+    - govuk-rota-announcer
+    - govuk-user-reviewer
+    - slimmer
 
 govuk-forms:
-  github_team: "forms-devs"
-
-  channel:
-    "#govuk-forms-tech"
-
-  exclude_titles:
-    - "[DO NOT MERGE]"
-    - "[PROTOTYPE]"
-    - WIP
-    - "[WIP]"
-
+  channel: '#govuk-forms-tech'
   compact: true
+  exclude_titles:
+    - DNM
+    - DO NOT MERGE
+    - DRAFT
+    - PARKED
+    - PROTOTYPE
+    - WIP
+  github_team: forms-devs
+
+govuk-frontenders:
+  channel: '#govuk-frontenders'
+  exclude_titles:
+    - DNM
+    - DO NOT MERGE
+    - DRAFT
+    - PARKED
+    - PROTOTYPE
+    - WIP
+  repos:
+    - govuk_publishing_components
+    - stylelint-config-gds
+
+govuk-green-team:
+  channel: '#govuk-green-team'
+  quotes:
+    - 'Remember to make time for personal development :big-brain:'
+    - 'Remember to make time for community and corporate objectives :handshake:'
+    - 'Remember to make time for wellbeing :happyseal:'
+    - 'Remember to celebrating maintaining content :celebrate:'
+    - 'Remember to fill out the <https://docs.google.com/spreadsheets/d/1MV7ASHzDj_FWxix2tCo_EpuBmK0uvuYPnwjijjGIp00/edit#gid=0|spreadsheet> if you''re going into the office soon so your teammates can look out for you. :office:'
+    - Remember to add <https://docs.google.com/document/d/14L5FbIxpTEcjTXgA2deTAupr4y8n3JcIJixNSH5Czz0/edit|QOTDs> to the pinned list when you think of them
+    - 'Remember to read or add entries to the monthly newsletter (pinned to the channel) and find out what the team has been doing lately! :newspaper:'
+    - 'Remember to <https://forms.gle/DdzRiptNuYQqA1Xn9|let me know> if there’s anything else I can help with or if you have any feedback. :mega:'
+
+govuk-pay:
+  channel: '#govuk-pay-tech'
+  exclude_titles:
+    - DO NOT MERGE
+    - '[DRAFT]'
+    - WIP
 
 govuk-platform-reliability:
-  channel:
-    "#govuk-platform-reliability-team"
-
+  channel: '#govuk-platform-reliability-team'
+  compact: true
   exclude_titles:
-    - "[DO NOT MERGE]"
-    - "WIP"
-
+    - DNM
+    - DO NOT MERGE
+    - DRAFT
+    - PARKED
+    - PROTOTYPE
+    - WIP
   quotes:
     - Be ready and willing to pair on work
     - Slack as primary point of contact; email for things you want to remember
@@ -213,85 +270,155 @@ govuk-platform-reliability:
     - Try with each bit of work to upskill others
     - It's okay to spend some time understanding the thing(s) before implementing the solution
     - It's OK to pick up and work on something you don't understand yet
-
-  compact: true
-
-govuk-pay:
-  channel:
-    "#govuk-pay-tech"
-
-  exclude_titles:
-    - "[DO NOT MERGE]"
-    - "[DRAFT]"
-    - WIP
+  repos:
+    - bulk-merger
+    - content-data-admin
+    - content-data-api
+    - gds_zendesk
+    - govuk-app-deployment
+    - govuk-aws
+    - govuk-aws-data
+    - govuk-cdn-config
+    - govuk-dependencies
+    - govuk-dependency-checker
+    - govuk-deploy-lag-badger
+    - govuk-dns
+    - govuk-jenkinslib
+    - govuk-lambda-app-deployment
+    - govuk-load-testing
+    - govuk-paas-office-ip-router
+    - govuk-pact-broker
+    - govuk-puppet
+    - govuk-repo-mirror
+    - govuk-saas-config
+    - govuk-secondline-blinken
+    - govuk-secrets
+    - govuk-sentry-monitor
+    - govuk-zendesk-display-screen
+    - govuk_app_config
+    - govuk_crawler_worker
+    - govuk_seed_crawler
+    - govuk_test
+    - icinga_slack_webhook
+    - locations-api
+    - mapit
+    - mapit-scripts
+    - packager
+    - plek
+    - puppet-gor
+    - rack-logstasher
+    - release
+    - rubocop-govuk
+    - seal
+    - smokey
+    - support
+    - support-api
+    - upgrade-ruby-version
 
 govuk-publishing-experience:
-  channel:
-    "#govuk-publishing-experience-tech"
-
-  exclude_title:
-    - "[DO NOT MERGE]"
-    - "WIP"
-    - "[WIP]"
-
-  compact: true
-
-govuk-publishing-platform:
-  channel:
-    "#govuk-publishing-platform"
-
-  exclude_title:
-    - "[DO NOT MERGE]"
-    - "WIP"
-    - "[WIP]"
-
-  compact: true
-
-govuk-replatforming:
-  github_team: gov-uk-replatforming
-  channel: "#govuk-replatforming"
+  channel: '#govuk-publishing-experience-tech'
   compact: true
   exclude_titles:
-    - "[DNM]"
-    - "[DO NOT MERGE]"
-    - "[WIP]"
-    - "WIP "
-    - "WIP:"
+    - DNM
+    - DO NOT MERGE
+    - DRAFT
+    - PARKED
+    - PROTOTYPE
+    - WIP
+  repos:
+    - collections-publisher
+    - contacts-admin
+    - content-publisher
+    - content-tagger
+    - govuk_admin_template
+    - manuals-publisher
+    - maslow
+    - miller-columns-element
+    - paste-html-to-govspeak
+    - publisher
+    - service-manual-publisher
+    - short-url-manager
+    - special-route-publisher
+    - specialist-publisher
+    - travel-advice-publisher
+    - whitehall
+
+govuk-publishing-platform:
+  channel: '#govuk-publishing-platform'
+  compact: true
+  exclude_titles:
+    - DNM
+    - DO NOT MERGE
+    - DRAFT
+    - PARKED
+    - PROTOTYPE
+    - WIP
+  repos:
+    - asset-manager
+    - content-store
+    - gds-api-adapters
+    - gds-sso
+    - govspeak
+    - govspeak-preview
+    - govuk-content-api-docs
+    - govuk-content-schemas
+    - govuk_message_queue_consumer
+    - govuk_schemas
+    - govuk_sidekiq
+    - hmrc-manuals-api
+    - link-checker-api
+    - omniauth-gds
+    - optic14n
+    - publishing-api
+    - publishing-e2e-tests
+    - side-by-side-browser
+    - sidekiq-monitoring
+    - signon
+    - transition
+    - transition-config
+
+govuk-replatforming:
+  channel: '#govuk-replatforming'
+  compact: true
+  exclude_titles:
+    - DNM
+    - DO NOT MERGE
+    - DRAFT
+    - PARKED
+    - PROTOTYPE
+    - WIP
+  github_team: gov-uk-replatforming
   repos:
     - govuk-helm-charts
     - govuk-infrastructure
     - govuk-kubernetes-cluster-user-docs
 
 govwifi:
-  repos:
-    - "govwifi-acceptance-tests"
-    - "govwifi-admin"
-    - "govwifi-authentication-api"
-    - "govwifi-build"
-    - "govwifi-builder-task"
-    - "govwifi-concourse-deploy-pipeline"
-    - "govwifi-concourse-runner"
-    - "govwifi-dashboard"
-    - "govwifi-database-backup"
-    - "govwifi-dev-docs"
-    - "govwifi-frontend"
-    - "govwifi-logging-api"
-    - "govwifi-product-page"
-    - "govwifi-redirect"
-    - "govwifi-safe-restarter"
-    - "govwifi-shared-frontend"
-    - "govwifi-smoke-tests"
-    - "govwifi-tech-docs"
-    - "govwifi-terraform"
-    - "govwifi-user-signup-api"
-    - "govwifi-watchdog"
-
-  channel:
-    "#govwifi-monitoring"
-
+  channel: '#govwifi-monitoring'
   exclude_titles:
-    - "[DO NOT MERGE]"
-    - "[PROTOTYPE]"
+    - DO NOT MERGE
+    - PROTOTYPE
     - WIP
-    - "[WIP]"
-    - "[PARKED]"
+    - PARKED
+  repos:
+    - govwifi-acceptance-tests
+    - govwifi-admin
+    - govwifi-authentication-api
+    - govwifi-build
+    - govwifi-builder-task
+    - govwifi-concourse-deploy-pipeline
+    - govwifi-concourse-runner
+    - govwifi-dashboard
+    - govwifi-database-backup
+    - govwifi-dev-docs
+    - govwifi-frontend
+    - govwifi-logging-api
+    - govwifi-product-page
+    - govwifi-redirect
+    - govwifi-safe-restarter
+    - govwifi-shared-frontend
+    - govwifi-smoke-tests
+    - govwifi-tech-docs
+    - govwifi-terraform
+    - govwifi-user-signup-api
+    - govwifi-watchdog

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -257,13 +257,13 @@ govuk-replatforming:
     - "[WIP]"
     - "WIP "
     - "WIP:"
-  include_repos:
+  repos:
     - govuk-helm-charts
     - govuk-infrastructure
     - govuk-kubernetes-cluster-user-docs
 
 govwifi:
-  include_repos:
+  repos:
     - "govwifi-acceptance-tests"
     - "govwifi-admin"
     - "govwifi-authentication-api"

--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -11,9 +11,7 @@ class GithubFetcher
     @exclude_labels = team.exclude_labels.map(&:downcase).uniq
     @exclude_titles = team.exclude_titles.map(&:downcase).uniq
     @labels = {}
-    @exclude_repos = team.exclude_repos
-    @include_repos = get_team_repos(team.github_team, team.include_repos)
-    @sleep_time = ENV.has_key?("THROTTLE_SECS") ? ENV["THROTTLE_SECS"].to_i : 60
+    @repos = get_team_repos(team.github_team, team.repos)
   end
 
   def list_pull_requests
@@ -23,43 +21,39 @@ class GithubFetcher
   end
 
   def pull_requests_from_github
-    github.search_issues("is:pr state:open user:#{organisation} archived:false -is:draft", per_page: 100)
-    last_response = github.last_response
-    pulls = last_response.data.items
-    return [] if pulls.empty?
-
-    until last_response.rels[:next].nil?
-      sleep sleep_time
-      last_response = last_response.rels[:next].get
-      pulls << last_response.data.items
+    pulls = []
+    @repos.each do |repo|
+      github.pull_requests("#{organisation}/#{repo}", { state: :open, sort: :created })
+            .reject { |p| p.user.login.include?("dependabot") || p.draft }.each do |pr|
+              pulls << pr
+            end
     end
+
     pulls.flatten
   end
 
   private
 
   attr_reader :use_labels,
-    :exclude_labels,
-    :exclude_titles,
-    :exclude_repos,
-    :include_repos,
-    :organisation,
-    :github,
-    :sleep_time
+              :exclude_labels,
+              :exclude_titles,
+              :repos,
+              :organisation,
+              :github
 
   def present_pull_request(pull_request)
-    repo = repo_name(pull_request)
+    repo = pull_request.head.repo.name
 
     {
       title: pull_request.title,
       link: pull_request.html_url,
       author: pull_request.user.login,
-      repo: repo,
+      repo:,
       comments_count: count_comments(pull_request, repo),
       thumbs_up: count_thumbs_up(pull_request, repo),
       approved: approved?(pull_request, repo),
       updated: Date.parse(pull_request.updated_at.to_s),
-      labels: labels(pull_request, repo),
+      labels: labels(pull_request)
     }
   end
 
@@ -71,7 +65,7 @@ class GithubFetcher
   def count_thumbs_up(pull_request, repo)
     response = github.issue_comments("#{organisation}/#{repo}", pull_request.number)
     comments_string = response.map(&:body).join
-    thumbs_up = comments_string.scan(/:\+1:/).count
+    comments_string.scan(/:\+1:/).count
   end
 
   def approved?(pull_request, repo)
@@ -79,43 +73,22 @@ class GithubFetcher
     reviews.any? { |review| review.state == 'APPROVED' }
   end
 
-  def labels(pull_request, repo)
+  def labels(pull_request)
     return [] unless use_labels
-    key = "#{organisation}/#{repo}/#{pull_request.number}".to_sym
-    @labels[key] ||= github.labels_for_issue("#{organisation}/#{repo}", pull_request.number)
+
+    pull_request.labels.map { |label| label[:name].downcase }
   end
 
   def hidden?(pull_request)
-    repo = repo_name(pull_request)
-
-    excluded_repo?(repo) ||
-      excluded_label?(pull_request, repo) ||
-      excluded_title?(pull_request.title) ||
-      (include_repos.any? && !explicitly_included_repo?(repo))
+    excluded_label?(pull_request) || excluded_title?(pull_request.title)
   end
 
-  def excluded_label?(pull_request, repo)
-    return false unless exclude_labels.any?
-    lowercase_label_names = labels(pull_request, repo).map { |l| l['name'].downcase }
-    exclude_labels.any? { |e| lowercase_label_names.include?(e) }
+  def excluded_label?(pull_request)
+    exclude_labels.any? { |e| labels(pull_request).include?(e) }
   end
 
   def excluded_title?(title)
     exclude_titles.any? { |t| title.downcase.include?(t) }
-  end
-
-  def excluded_repo?(repo)
-    return false unless exclude_repos.any?
-    exclude_repos.include?(repo)
-  end
-
-  def explicitly_included_repo?(repo)
-    return false unless include_repos.any?
-    include_repos.include?(repo)
-  end
-
-  def repo_name(pr)
-    pr.html_url.split("/")[4]
   end
 
   def get_team_repos(team_slug, repos)
@@ -126,6 +99,6 @@ class GithubFetcher
   end
 
   def get_github_team_repos(team_slug)
-    github.get("/orgs/#{@organisation}/teams/#{team_slug}/repos").map{|repo| repo.name}
+    github.get("/orgs/#{@organisation}/teams/#{team_slug}/repos").map(&:name)
   end
 end

--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -1,9 +1,6 @@
 require "octokit"
 
 class GithubFetcher
-  # TODO: remove media type when review support comes out of preview
-  Octokit.default_media_type = "application/vnd.github.black-cat-preview+json"
-
   def initialize(team)
     @organisation = ENV["SEAL_ORGANISATION"]
     @github = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])

--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -32,7 +32,7 @@ class GithubFetcher
     pulls.flatten
   end
 
-  private
+private
 
   attr_reader :use_labels,
               :exclude_labels,
@@ -53,7 +53,7 @@ class GithubFetcher
       thumbs_up: count_thumbs_up(pull_request, repo),
       approved: approved?(pull_request, repo),
       updated: Date.parse(pull_request.updated_at.to_s),
-      labels: labels(pull_request)
+      labels: labels(pull_request),
     }
   end
 
@@ -70,7 +70,7 @@ class GithubFetcher
 
   def approved?(pull_request, repo)
     reviews = github.get("repos/#{organisation}/#{repo}/pulls/#{pull_request.number}/reviews")
-    reviews.any? { |review| review.state == 'APPROVED' }
+    reviews.any? { |review| review.state == "APPROVED" }
   end
 
   def labels(pull_request)

--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -25,8 +25,11 @@ class GithubFetcher
     @repos.each do |repo|
       github.pull_requests("#{organisation}/#{repo}", { state: :open, sort: :created })
             .reject { |p| p.user.login.include?("dependabot") || p.draft }.each do |pr|
-              pulls << pr
-            end
+        pulls << pr
+      end
+    rescue StandardError => e
+      puts e.message
+      next
     end
 
     pulls.flatten

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -24,17 +24,17 @@ class MessageBuilder
   def rotten?(pull_request)
     today = Date.today
     actual_age = (today - pull_request[:updated]).to_i
-    if today.monday?
-      weekdays_age = actual_age - 2
-    elsif today.tuesday?
-      weekdays_age = actual_age - 1
-    else
-      weekdays_age = actual_age
-    end
+    weekdays_age = if today.monday?
+                     actual_age - 2
+                   elsif today.tuesday?
+                     actual_age - 1
+                   else
+                     actual_age
+                   end
     weekdays_age > 2
   end
 
-  private
+private
 
   attr_reader :team
 
@@ -73,6 +73,7 @@ class MessageBuilder
 
   def comments(pull_request)
     return " comment" if pull_request[:comments_count] == 1
+
     " comments"
   end
 
@@ -98,11 +99,11 @@ class MessageBuilder
     @title = pr[:title]
     @days = age_in_days(@pr)
 
-    @thumbs_up = if @pr[:thumbs_up] > 0
-      " | #{@pr[:thumbs_up]} :+1:"
-    else
-      ""
-    end
+    @thumbs_up = if (@pr[:thumbs_up]).positive?
+                   " | #{@pr[:thumbs_up]} :+1:"
+                 else
+                   ""
+                 end
 
     @approved = @pr[:approved] ? " | :white_check_mark: " : ""
 
@@ -120,7 +121,7 @@ class MessageBuilder
   def days_plural(days)
     case days
     when 0
-      'today'
+      "today"
     when 1
       "yesterday"
     else
@@ -131,11 +132,11 @@ class MessageBuilder
   def labels(pull_request)
     pull_request[:labels]
       .map { |label| "[#{label['name']}]" }
-      .join(' ')
+      .join(" ")
   end
 
   def html_encode(string)
-    string.tr('&', '&amp;').tr('<', '&lt;').tr('>', '&gt;')
+    string.tr("&", "&amp;").tr("<", "&lt;").tr(">", "&gt;")
   end
 
   def apply_style(template_name)

--- a/lib/seal.rb
+++ b/lib/seal.rb
@@ -11,21 +11,21 @@ class Seal
 
   def bark(mode: nil)
     teams.each do |team|
-      bark_at(team, mode: mode)
+      bark_at(team, mode:)
     end
   end
 
-  private
+private
 
   attr_reader :teams
 
   def bark_at(team, mode: nil)
     message = case mode
-    when "quotes"
-      Message.new(team.quotes.sample)
-    else
-      MessageBuilder.new(team).build
-    end
+              when "quotes"
+                Message.new(team.quotes.sample)
+              else
+                MessageBuilder.new(team).build
+              end
 
     poster = SlackPoster.new(team.channel, message.mood)
     poster.send_request(message.text)

--- a/lib/slack_poster.rb
+++ b/lib/slack_poster.rb
@@ -1,11 +1,10 @@
-require 'slack-poster'
+require "slack-poster"
 
 class SlackPoster
-
   attr_accessor :webhook_url, :poster, :mood, :mood_hash, :channel, :season_name, :halloween_season, :festive_season
 
   def initialize(team_channel, mood)
-    @webhook_url = ENV['SLACK_WEBHOOK']
+    @webhook_url = ENV["SLACK_WEBHOOK"]
     @team_channel = team_channel
     @mood = mood
     @today = Date.today
@@ -16,29 +15,29 @@ class SlackPoster
   end
 
   def create_poster
-    @poster = Slack::Poster.new("#{webhook_url}", slack_options)
+    @poster = Slack::Poster.new(webhook_url.to_s, slack_options)
   end
 
   def send_request(message)
-    if ENV['DRY']
+    if ENV["DRY"]
       puts "Will#{' not' unless postable_day} post #{mood} message to #{channel} on #{today.strftime('%A')}"
       puts slack_options.inspect
       puts message
-    else
-      poster.send_message(message) if postable_day
+    elsif postable_day
+      poster.send_message(message)
     end
   end
 
-  private
+private
 
   attr_reader :postable_day, :today
 
   def slack_options
     {
-     icon_emoji: @mood_hash[:icon_emoji],
-     username: @mood_hash[:username],
-     channel: @team_channel
-   }
+      icon_emoji: @mood_hash[:icon_emoji],
+      username: @mood_hash[:username],
+      channel: @team_channel,
+    }
   end
 
   def mood_hash
@@ -49,52 +48,54 @@ class SlackPoster
   end
 
   def assign_poster_settings
-    if @mood == "informative"
-      @mood_hash[:icon_emoji]= ":#{@season_symbol}informative_seal:"
-      @mood_hash[:username]= "#{@season_name}Informative Seal"
-    elsif @mood == "approval"
-      @mood_hash[:icon_emoji]= ":#{@season_symbol}seal_of_approval:"
-      @mood_hash[:username]= "#{@season_name}Seal of Approval"
-    elsif @mood == "angry"
-      @mood_hash[:icon_emoji]= ":#{@season_symbol}angrier_seal:"
-      @mood_hash[:username]= "#{@season_name}Angry Seal"
-    elsif @mood == "tea"
-      @mood_hash[:icon_emoji]= ":manatea:"
-      @mood_hash[:username]= "Tea Seal"
-    elsif @mood == "charter"
-      @mood_hash[:icon_emoji]= ":happyseal:"
-      @mood_hash[:username]= "Team Charter Seal"
-    elsif @mood == "fun-workstream"
-      @mood_hash[:icon_emoji]= ":wholesome-seal:"
-      @mood_hash[:username]= "It's ok Seal"
-    elsif @mood == "govuk-green-team"
-      @mood_hash[:icon_emoji]=":happybabyseal:"
-      @mood_hash[:username]= "Elephant Seal"
+    case @mood
+    when "informative"
+      @mood_hash[:icon_emoji] = ":#{@season_symbol}informative_seal:"
+      @mood_hash[:username] = "#{@season_name}Informative Seal"
+    when "approval"
+      @mood_hash[:icon_emoji] = ":#{@season_symbol}seal_of_approval:"
+      @mood_hash[:username] = "#{@season_name}Seal of Approval"
+    when "angry"
+      @mood_hash[:icon_emoji] = ":#{@season_symbol}angrier_seal:"
+      @mood_hash[:username] = "#{@season_name}Angry Seal"
+    when "tea"
+      @mood_hash[:icon_emoji] = ":manatea:"
+      @mood_hash[:username] = "Tea Seal"
+    when "charter"
+      @mood_hash[:icon_emoji] = ":happyseal:"
+      @mood_hash[:username] = "Team Charter Seal"
+    when "fun-workstream"
+      @mood_hash[:icon_emoji] = ":wholesome-seal:"
+      @mood_hash[:username] = "It's ok Seal"
+    when "govuk-green-team"
+      @mood_hash[:icon_emoji] = ":happybabyseal:"
+      @mood_hash[:username] = "Elephant Seal"
     else
-      fail "Bad mood: #{mood}."
+      raise "Bad mood: #{mood}."
     end
   end
 
   def check_season
-    if halloween_season?
-      @season_name = "Halloween "
-    elsif festive_season?
-      @season_name = "Festive Season "
-    else
-      @season_name = ""
-    end
+    @season_name = if halloween_season?
+                     "Halloween "
+                   elsif festive_season?
+                     "Festive Season "
+                   else
+                     ""
+                   end
     @season_symbol = snake_case(@season_name)
   end
 
   def halloween_season?
     this_year = today.year
-    today <= Date.new(this_year, 10, 31) && today >= Date.new(this_year,10,23)
+    today <= Date.new(this_year, 10, 31) && today >= Date.new(this_year, 10, 23)
   end
 
   def festive_season?
     this_year = today.year
-    return true if today <= Date.new(this_year, 12, 31) && today >= Date.new(this_year,12,1)
-    today == Date.new(this_year, 01, 01)
+    return true if today <= Date.new(this_year, 12, 31) && today >= Date.new(this_year, 12, 1)
+
+    today == Date.new(this_year, 1, 1)
   end
 
   def snake_case(string)
@@ -105,16 +106,16 @@ class SlackPoster
     if @team_channel == "#club-tea"
       @mood = "tea"
     # If the channel name is either govuk or gds-community, set the mood to 'fun-workstream'
-    elsif ['#govuk', '#gds-community', '#sealtesting'].include?(@team_channel)
-       @mood = "fun-workstream"
-     elsif @team_channel == "#govuk-green-team"
-       @mood = "govuk-green-team"
-    elsif @mood == nil
+    elsif ["#govuk", "#gds-community", "#sealtesting"].include?(@team_channel)
+      @mood = "fun-workstream"
+    elsif @team_channel == "#govuk-green-team"
+      @mood = "govuk-green-team"
+    elsif @mood.nil?
       @mood = "charter"
     end
   end
 
   def channel
-    @team_channel = '#bot-testing' if ENV["DYNO"].nil?
+    @team_channel = "#bot-testing" if ENV["DYNO"].nil?
   end
 end

--- a/lib/team.rb
+++ b/lib/team.rb
@@ -1,15 +1,15 @@
 class Team
   def initialize(
-                  github_team: nil,
-                  use_labels: nil,
-                  compact: nil,
-                  exclude_labels: nil,
-                  exclude_titles: nil,
-                  repos: nil,
-                  quotes: nil,
-                  slack_channel: nil
-                )
-    @github_team  = github_team
+    github_team: nil,
+    use_labels: nil,
+    compact: nil,
+    exclude_labels: nil,
+    exclude_titles: nil,
+    repos: nil,
+    quotes: nil,
+    slack_channel: nil
+  )
+    @github_team = github_team
     @use_labels = (use_labels.nil? ? false : use_labels)
     @compact = (compact.nil? ? false : compact)
     @exclude_labels = exclude_labels || []
@@ -19,7 +19,7 @@ class Team
     @channel = slack_channel
   end
 
-  attr_reader *%i[
+  attr_reader(*%i[
     github_team
     use_labels
     compact
@@ -28,5 +28,5 @@ class Team
     repos
     quotes
     channel
-  ]
+  ])
 end

--- a/lib/team.rb
+++ b/lib/team.rb
@@ -1,6 +1,5 @@
 class Team
   def initialize(
-                  members: nil,
                   github_team: nil,
                   use_labels: nil,
                   compact: nil,
@@ -11,7 +10,6 @@ class Team
                   quotes: nil,
                   slack_channel: nil
                 )
-    @members = members || []
     @github_team  = github_team
     @use_labels = (use_labels.nil? ? false : use_labels)
     @compact = (compact.nil? ? false : compact)
@@ -24,7 +22,6 @@ class Team
   end
 
   attr_reader *%i[
-    members
     github_team
     use_labels
     compact

--- a/lib/team.rb
+++ b/lib/team.rb
@@ -5,8 +5,7 @@ class Team
                   compact: nil,
                   exclude_labels: nil,
                   exclude_titles: nil,
-                  exclude_repos: nil,
-                  include_repos: nil,
+                  repos: nil,
                   quotes: nil,
                   slack_channel: nil
                 )
@@ -15,8 +14,7 @@ class Team
     @compact = (compact.nil? ? false : compact)
     @exclude_labels = exclude_labels || []
     @exclude_titles = exclude_titles || []
-    @exclude_repos = exclude_repos || []
-    @include_repos = include_repos || []
+    @repos = repos || []
     @quotes = quotes || []
     @channel = slack_channel
   end
@@ -27,8 +25,7 @@ class Team
     compact
     exclude_labels
     exclude_titles
-    exclude_repos
-    include_repos
+    repos
     quotes
     channel
   ]

--- a/lib/team_builder.rb
+++ b/lib/team_builder.rb
@@ -43,8 +43,7 @@ class TeamBuilder
       compact: env["COMPACT"] == "true" || config["compact"],
       exclude_labels: env["GITHUB_EXCLUDE_LABELS"]&.split(',') || config["exclude_labels"],
       exclude_titles: env["GITHUB_EXCLUDE_TITLES"]&.split(',') || config["exclude_titles"],
-      exclude_repos: env["GITHUB_EXCLUDE_REPOS"]&.split(',') || config["exclude_repos"],
-      include_repos: env["GITHUB_INCLUDE_REPOS"]&.split(',') || config["include_repos"],
+      repos: env["GITHUB_REPOS"]&.split(',') || config["repos"],
       quotes: env["SEAL_QUOTES"]&.split(',') || config["quotes"],
       slack_channel: env["SLACK_CHANNEL"] || config["channel"],
     }

--- a/lib/team_builder.rb
+++ b/lib/team_builder.rb
@@ -2,7 +2,7 @@ require_relative "team"
 
 class TeamBuilder
   def self.build(env: {}, team_name: nil)
-    self.new(env).build(team_name)
+    new(env).build(team_name)
   end
 
   def initialize(env)
@@ -17,7 +17,7 @@ class TeamBuilder
     end
   end
 
-  private
+private
 
   attr_reader :env
 
@@ -41,10 +41,10 @@ class TeamBuilder
       github_team: env["GITHUB_TEAM"] || config["github_team"],
       use_labels: env["GITHUB_USE_LABELS"] == "true" || config["use_labels"],
       compact: env["COMPACT"] == "true" || config["compact"],
-      exclude_labels: env["GITHUB_EXCLUDE_LABELS"]&.split(',') || config["exclude_labels"],
-      exclude_titles: env["GITHUB_EXCLUDE_TITLES"]&.split(',') || config["exclude_titles"],
-      repos: env["GITHUB_REPOS"]&.split(',') || config["repos"],
-      quotes: env["SEAL_QUOTES"]&.split(',') || config["quotes"],
+      exclude_labels: env["GITHUB_EXCLUDE_LABELS"]&.split(",") || config["exclude_labels"],
+      exclude_titles: env["GITHUB_EXCLUDE_TITLES"]&.split(",") || config["exclude_titles"],
+      repos: env["GITHUB_REPOS"]&.split(",") || config["repos"],
+      quotes: env["SEAL_QUOTES"]&.split(",") || config["quotes"],
       slack_channel: env["SLACK_CHANNEL"] || config["channel"],
     }
   end

--- a/lib/team_builder.rb
+++ b/lib/team_builder.rb
@@ -38,7 +38,6 @@ class TeamBuilder
 
   def apply_env(config)
     {
-      members: env["GITHUB_MEMBERS"]&.split(",") || config["members"],
       github_team: env["GITHUB_TEAM"] || config["github_team"],
       use_labels: env["GITHUB_USE_LABELS"] == "true" || config["use_labels"],
       compact: env["COMPACT"] == "true" || config["compact"],

--- a/server.rb
+++ b/server.rb
@@ -1,17 +1,16 @@
-require 'sinatra'
-require './lib/seal'
-require './lib/github_fetcher'
-require './lib/message_builder'
-require './lib/slack_poster'
-require './lib/team_builder'
+require "sinatra"
+require "./lib/seal"
+require "./lib/github_fetcher"
+require "./lib/message_builder"
+require "./lib/slack_poster"
+require "./lib/team_builder"
 
 class SealApp < Sinatra::Base
-
-  get '/' do
+  get "/" do
     "Hello Seal"
   end
 
-  post '/bark/:team_name/:secret' do
+  post "/bark/:team_name/:secret" do
     if params[:secret] == ENV["SEAL_SECRET"]
       team = TeamBuilder.build(env: ENV, team_name: params[:team_name])
       Seal.new(team).bark
@@ -19,10 +18,10 @@ class SealApp < Sinatra::Base
     end
   end
 
-  post '/bark-quotes/:team_name/:secret' do
+  post "/bark-quotes/:team_name/:secret" do
     if params[:secret] == ENV["SEAL_SECRET"]
       team = TeamBuilder.build(env: ENV, team_name: params[:team_name])
-      Seal.new(team).bark(mode: 'quotes')
+      Seal.new(team).bark(mode: "quotes")
       "Seal received message with #{params[:team_name]} team name for quotes"
     end
   end

--- a/server.rb
+++ b/server.rb
@@ -19,9 +19,11 @@ class SealApp < Sinatra::Base
     end
   end
 
-  post '/bark-quotes/:team_name' do
-    team = TeamBuilder.build(env: ENV, team_name: params[:team_name])
-    Seal.new(team).bark(mode: 'quotes')
-    "Seal received message with #{params[:team_name]} team name for quotes"
+  post '/bark-quotes/:team_name/:secret' do
+    if params[:secret] == ENV["SEAL_SECRET"]
+      team = TeamBuilder.build(env: ENV, team_name: params[:team_name])
+      Seal.new(team).bark(mode: 'quotes')
+      "Seal received message with #{params[:team_name]} team name for quotes"
+    end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,8 +1,8 @@
-require 'spec_helper'
+require "spec_helper"
 
-describe 'config/alphagov.yml' do
-  it 'is valid YAML' do
-    config = YAML.load_file('config/alphagov.yml')
+describe "config/alphagov.yml" do
+  it "is valid YAML" do
+    config = YAML.load_file("config/alphagov.yml")
 
     expect(config).to be_a(Hash)
   end

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -18,23 +18,8 @@ RSpec.describe GithubFetcher do
 
   let(:fake_octokit_client) { double(Octokit::Client) }
   let(:whitehall_repo_name) { "#{ENV['SEAL_ORGANISATION']}/whitehall" }
-  let(:whitehall_rebuild_repo_name) { "#{ENV['SEAL_ORGANISATION']}/whitehall-rebuild" }
-  let(:whitehall_security_repo_name) { "#{ENV['SEAL_ORGANISATION']}/whitehall-security" }
-  let(:blocked_and_wip) do
-    [
-      {
-        "url" => "https://api.github.com/repos/alphagov/whitehall/labels/blocked",
-        "name" => "blocked",
-        "color" => "e11d21",
-      },
-      {
-        "url" => "https://api.github.com/repos/alphagov/whitehall/labels/wip",
-        "name" => "wip",
-        "color" => "fbca04",
-      },
-    ]
-  end
-
+  let(:govuk_docker_repo_name) { "#{ENV['SEAL_ORGANISATION']}/govuk-docker" }
+  let(:content_store_repo_name) { "#{ENV['SEAL_ORGANISATION']}/content-store" }
   let(:expected_open_prs) do
     [
       {
@@ -46,28 +31,37 @@ RSpec.describe GithubFetcher do
         thumbs_up: 1,
         approved: false,
         updated: Date.parse("2015-07-13 ((2457217j,0s,0n),+0s,2299161j)"),
-        labels: [],
+        labels: wip_or_not,
       },
 
       {
         title: "Remove all Import-related code",
-        link: "https://github.com/alphagov/whitehall-rebuild/pull/2248",
+        link: "https://github.com/alphagov/govuk-docker/pull/2248",
         author: "tekin",
-        repo: "whitehall-rebuild",
+        repo: "govuk-docker",
         comments_count: 5,
         thumbs_up: 0,
         approved: true,
         updated: Date.parse("2015-07-17 ((2457221j,0s,0n),+0s,2299161j)"),
-        labels:,
+        labels: [],
+      },
+      {
+        approved: false,
+        author: "lauramipsum",
+        comments_count: 0,
+        labels: [],
+        link: "https://github.com/alphagov/content-store/pull/2295",
+        repo: "content-store",
+        thumbs_up: 0,
+        title: "Enable ssh key signing",
+        updated: Date.parse("2015-07-17 ((2457221j,0s,0n),+0s,2299161j)"),
       },
     ]
   end
 
-  let(:labels) { [] }
-
   let(:exclude_labels) { nil }
   let(:exclude_titles) { nil }
-  let(:repos) { nil }
+  let(:repos) { %w[whitehall govuk-docker content-store] }
 
   let(:github_team) { nil }
 
@@ -79,29 +73,40 @@ RSpec.describe GithubFetcher do
            number: 2266,
            review_comments: 1,
            comments: 0,
-           updated_at: "2015-07-13 01:00:44 UTC")
+           updated_at: "2015-07-13 01:00:44 UTC",
+           draft: false,
+           head: double(Sawyer::Resource, repo: double(Sawyer::Resource, name: "whitehall")),
+           labels: [
+             { name: "wip" },
+           ])
   end
 
   let(:pull_2248) do
     double(Sawyer::Resource,
            user: double(Sawyer::Resource, login: "tekin"),
            title: "Remove all Import-related code",
-           html_url: "https://github.com/alphagov/whitehall-rebuild/pull/2248",
+           html_url: "https://github.com/alphagov/govuk-docker/pull/2248",
            number: 2248,
            review_comments: 1,
            comments: 4,
-           updated_at: "2015-07-17 01:00:44 UTC")
+           updated_at: "2015-07-17 01:00:44 UTC",
+           draft: false,
+           head: double(Sawyer::Resource, repo: double(Sawyer::Resource, name: "govuk-docker")),
+           labels: [])
   end
 
   let(:pull_2295) do
     double(Sawyer::Resource,
            user: double(Sawyer::Resource, login: "lauramipsum"),
            title: "Enable ssh key signing",
-           html_url: "https://github.com/alphagov/whitehall-security/pull/2295",
+           html_url: "https://github.com/alphagov/content-store/pull/2295",
            number: 2295,
            review_comments: 0,
            comments: 0,
-           updated_at: "2015-07-17 01:00:44 UTC")
+           updated_at: "2015-07-17 01:00:44 UTC",
+           draft: false,
+           head: double(Sawyer::Resource, repo: double(Sawyer::Resource, name: "content-store")),
+           labels: [])
   end
 
   let(:comments_2266) do
@@ -135,25 +140,37 @@ RSpec.describe GithubFetcher do
 
   let(:titles) { github_fetcher.list_pull_requests.map { |pr| pr[:title] } }
 
+  let(:no_prs) { [] }
+
   before do
     allow(Octokit::Client).to receive(:new).and_return(fake_octokit_client)
     allow(fake_octokit_client).to receive_message_chain("user.login")
     allow(fake_octokit_client).to receive(:auto_paginate=).with(false)
-    response = double(items: [pull_2266, pull_2248, pull_2295])
-    allow(fake_octokit_client).to receive(:search_issues).with(
-      "is:pr state:open user:alphagov archived:false -is:draft", per_page: 100
-    ).and_return(response)
-    allow(fake_octokit_client).to receive(:last_response).and_return(double(data: response, rels: { next: nil }))
+
+    allow(fake_octokit_client).to receive(:pull_requests).with(
+      "alphagov/whitehall", { state: :open, sort: :created }
+    ).and_return([pull_2266])
+
+    allow(fake_octokit_client).to receive(:pull_requests).with(
+      "alphagov/govuk-docker", { state: :open, sort: :created }
+    ).and_return([pull_2248])
+
+    allow(fake_octokit_client).to receive(:pull_requests).with(
+      "alphagov/content-store", { state: :open, sort: :created }
+    ).and_return([pull_2295])
 
     allow(fake_octokit_client).to receive(:issue_comments).with(whitehall_repo_name, 2266).and_return(comments_2266)
-    allow(fake_octokit_client).to receive(:issue_comments).with(whitehall_rebuild_repo_name,
+    allow(fake_octokit_client).to receive(:issue_comments).with(govuk_docker_repo_name,
                                                                 2248).and_return(comments_2248)
+    allow(fake_octokit_client).to receive(:issue_comments).with(content_store_repo_name, 2295).and_return(comments_2295)
 
-    allow(fake_octokit_client).to receive(:pull_request).with(whitehall_rebuild_repo_name, 2248).and_return(pull_2248)
+    allow(fake_octokit_client).to receive(:pull_request).with(govuk_docker_repo_name, 2248).and_return(pull_2248)
     allow(fake_octokit_client).to receive(:pull_request).with(whitehall_repo_name, 2266).and_return(pull_2266)
+    allow(fake_octokit_client).to receive(:pull_request).with(content_store_repo_name, 2295).and_return(pull_2295)
 
     allow(fake_octokit_client).to receive(:get).with(%r{repos/alphagov/[\w-]+/pulls/2248/reviews}).and_return(reviews_2248)
     allow(fake_octokit_client).to receive(:get).with(%r{repos/alphagov/[\w-]+/pulls/2266/reviews}).and_return(reviews_2266)
+    allow(fake_octokit_client).to receive(:get).with(%r{repos/alphagov/[\w-]+/pulls/2295/reviews}).and_return(reviews_2295)
   end
 
   shared_examples_for "fetching from GitHub" do
@@ -165,122 +182,74 @@ RSpec.describe GithubFetcher do
 
     describe "#pull_requests_from_github" do
       it "returns an empty array when there are no items returned from search" do
-        allow(fake_octokit_client).to receive(:last_response).and_return(
-          double(data: double(items: []), rels: { next: nil }),
-        )
+        allow(fake_octokit_client).to receive(:pull_requests).and_return(no_prs)
 
         expect(github_fetcher.pull_requests_from_github).to eq([])
-      end
-
-      it "steps through each page of results" do
-        ENV["THROTTLE_SECS"] = "0"
-        second_page = double(data: double(items: [pull_2248]), rels: { next: nil })
-        first_page = double(data: double(items: [pull_2266]), rels: { next: double(get: second_page) })
-        allow(fake_octokit_client).to receive(:last_response).and_return(first_page)
-
-        expect(github_fetcher.pull_requests_from_github).to eq([pull_2266, pull_2248])
       end
     end
   end
 
   context "labels turned on" do
     let(:use_labels) { true }
-    let(:labels) { blocked_and_wip }
-
-    before do
-      allow(fake_octokit_client).to receive(:labels_for_issue).with(whitehall_rebuild_repo_name,
-                                                                    2248).and_return(blocked_and_wip)
-      allow(fake_octokit_client).to receive(:labels_for_issue).with(whitehall_repo_name, 2266).and_return([])
-      allow(fake_octokit_client).to receive(:labels_for_issue).with(whitehall_security_repo_name, 2295).and_return([])
-    end
-
-    context "excluding nothing" do
-      it_behaves_like "fetching from GitHub"
-    end
 
     context 'excluding "designer" label' do
       let(:exclude_labels) { %w[designer] }
+      let(:wip_or_not) { %w[wip] }
 
       it_behaves_like "fetching from GitHub"
-    end
-
-    context 'excluding "WIP" label' do
-      let(:exclude_labels) { %w[WIP] }
-
-      it "filters out the WIP" do
-        expect(titles).not_to include("Remove all Import-related code")
-        expect(titles).to include("[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host")
-      end
     end
 
     context 'excluding "wip" label' do
       let(:exclude_labels) { %w[wip] }
 
       it "filters out the wip" do
-        expect(titles).not_to include("Remove all Import-related code")
-        expect(titles).to include("[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host")
-      end
-    end
-
-    context 'excluding "whitehall-rebuild" repo' do
-      let(:repos) { %w[whitehall-rebuild] }
-
-      it 'filters out PRs NOT from the "whitehall-rebuild" repo' do
-        expect(titles).to match_array(["Remove all Import-related code"])
+        expect(titles).to include("Remove all Import-related code")
+        expect(titles).not_to include("[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host")
       end
     end
   end
 
-  context "labels turned off" do
+  context "title exclusions" do
     let(:use_labels) { false }
 
-    it_behaves_like "fetching from GitHub"
-    context "title exclusions" do
-      context "excluding no titles" do
-        it_behaves_like "fetching from GitHub"
-      end
+    context "excluding no titles" do
+      let(:wip_or_not) { [] }
 
-      context 'excluding "BLAH BLAH BLAH" title' do
-        let(:exclude_titles) { ["BLAH BLAH BLAH"] }
+      it_behaves_like "fetching from GitHub"
+    end
 
-        it_behaves_like "fetching from GitHub"
-      end
+    context 'excluding "BLAH BLAH BLAH" title' do
+      let(:exclude_titles) { ["BLAH BLAH BLAH"] }
+      let(:wip_or_not) { [] }
 
-      context 'excluding "DISCUSSION" title' do
-        let(:exclude_titles) { ["FOR DISCUSSION ONLY"] }
+      it_behaves_like "fetching from GitHub"
+    end
 
-        it "filters out the DISCUSSION" do
-          expect(titles).not_to include("[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host")
-          expect(titles).to include("Remove all Import-related code")
-        end
-      end
+    context 'excluding "DISCUSSION" title' do
+      let(:exclude_titles) { ["FOR DISCUSSION ONLY"] }
 
-      context 'excluding "discussion" title' do
-        let(:exclude_titles) { ["for discussion only"] }
-
-        it "filters out the discussion" do
-          expect(titles).not_to include("[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host")
-          expect(titles).to include("Remove all Import-related code")
-        end
+      it "filters out the DISCUSSION" do
+        expect(titles).not_to include("[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host")
+        expect(titles).to include("Remove all Import-related code")
       end
     end
   end
 
   context "with github team configured" do
     let(:use_labels) { false }
-    let(:github_team) { "whitehall-security-devs" }
+    let(:github_team) { "content-store-devs" }
 
     let(:github_team_repos) do
       [
-        double(Sawyer::Resource, name: "whitehall-security"),
+        double(Sawyer::Resource, name: "content-store"),
       ]
     end
 
     before do
       allow(fake_octokit_client).to receive(:get).with("/orgs/#{ENV['SEAL_ORGANISATION']}/teams/#{github_team}/repos").and_return(github_team_repos)
-      allow(fake_octokit_client).to receive(:issue_comments).with(whitehall_security_repo_name,
+      allow(fake_octokit_client).to receive(:issue_comments).with(content_store_repo_name,
                                                                   2295).and_return(comments_2295)
-      allow(fake_octokit_client).to receive(:pull_request).with(whitehall_security_repo_name,
+      allow(fake_octokit_client).to receive(:pull_request).with(content_store_repo_name,
                                                                 2295).and_return(pull_2295)
       allow(fake_octokit_client).to receive(:get).with(%r{repos/alphagov/[\w-]+/pulls/2295/reviews}).and_return(reviews_2295)
     end
@@ -294,7 +263,7 @@ RSpec.describe GithubFetcher do
     end
 
     context "with repos configured" do
-      let(:repos) { %w[whitehall whitehall-rebuild] }
+      let(:repos) { %w[whitehall govuk-docker] }
 
       it "shows PRs for repos owned by the github team and the additional configured repos" do
         expect(titles).to match_array(["Enable ssh key signing",

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -4,7 +4,6 @@ require_relative "../lib/github_fetcher"
 RSpec.describe GithubFetcher do
   let(:team) {
     Team.new(
-      members: team_members_accounts,
       github_team: github_team,
       use_labels: use_labels,
       exclude_labels: exclude_labels,
@@ -72,7 +71,6 @@ RSpec.describe GithubFetcher do
   let(:exclude_repos) { nil }
   let(:include_repos) { nil }
 
-  let(:team_members_accounts) { %w(binaryberry boffbowsh jackscotti tekin elliotcm tommyp mattbostock) }
   let(:github_team) { nil }
 
   let(:pull_2266) do
@@ -162,7 +160,7 @@ RSpec.describe GithubFetcher do
 
   shared_examples_for 'fetching from GitHub' do
     describe '#list_pull_requests' do
-      it "displays open pull requests open on the team's repos by a team member" do
+      it "displays open pull requests open on the team's repos" do
         expect(github_fetcher.list_pull_requests).to match expected_open_prs
       end
     end
@@ -290,12 +288,6 @@ RSpec.describe GithubFetcher do
     let(:use_labels) { false }
     let(:github_team) { 'whitehall-security-devs' }
 
-    let(:github_team_members) do
-      [
-        double(Sawyer::Resource, login: "lauramipsum" )
-      ]
-    end
-
     let(:github_team_repos) do
       [
         double(Sawyer::Resource, name: "whitehall-security" )
@@ -303,28 +295,10 @@ RSpec.describe GithubFetcher do
     end
 
     before do
-      allow(fake_octokit_client).to receive(:get).with("/orgs/#{ENV['SEAL_ORGANISATION']}/teams/#{github_team}/members").and_return(github_team_members)
       allow(fake_octokit_client).to receive(:get).with("/orgs/#{ENV['SEAL_ORGANISATION']}/teams/#{github_team}/repos").and_return(github_team_repos)
       allow(fake_octokit_client).to receive(:issue_comments).with(whitehall_security_repo_name, 2295).and_return(comments_2295)
       allow(fake_octokit_client).to receive(:pull_request).with(whitehall_security_repo_name, 2295).and_return(pull_2295)
       allow(fake_octokit_client).to receive(:get).with(%r"repos/alphagov/[\w-]+/pulls/2295/reviews").and_return(reviews_2295)
-    end
-
-    context 'with no team members configured' do
-      let(:include_repos) { ['whitehall', 'whitehall-rebuild', 'whitehall-security'] }
-      let(:team_members_accounts) { [] }
-
-      it 'only shows PRs for members of the github team' do
-        expect(titles).to match_array(["Enable ssh key signing"])
-      end
-    end
-     
-    context 'with additional team members configured' do
-      let(:include_repos) { ['whitehall', 'whitehall-rebuild', 'whitehall-security'] }
-
-      it 'shows PRs for members of the github team and the additional team members' do
-        expect(titles).to match_array(["Enable ssh key signing","Remove all Import-related code","[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host"])
-      end
     end
      
     context 'without include_repos configured' do

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -2,15 +2,15 @@ require "spec_helper"
 require_relative "../lib/github_fetcher"
 
 RSpec.describe GithubFetcher do
-  let(:team) {
+  let(:team) do
     Team.new(
-      github_team: github_team,
-      use_labels: use_labels,
-      exclude_labels: exclude_labels,
-      exclude_titles: exclude_titles,
-      repos: repos,
+      github_team:,
+      use_labels:,
+      exclude_labels:,
+      exclude_titles:,
+      repos:,
     )
-  }
+  end
 
   subject(:github_fetcher) do
     described_class.new(team)
@@ -23,43 +23,43 @@ RSpec.describe GithubFetcher do
   let(:blocked_and_wip) do
     [
       {
-        'url' => 'https://api.github.com/repos/alphagov/whitehall/labels/blocked',
-        'name' => 'blocked',
-        'color' => 'e11d21'
+        "url" => "https://api.github.com/repos/alphagov/whitehall/labels/blocked",
+        "name" => "blocked",
+        "color" => "e11d21",
       },
       {
-        'url' => 'https://api.github.com/repos/alphagov/whitehall/labels/wip',
-        'name' => 'wip',
-        'color' => 'fbca04'
-      }
+        "url" => "https://api.github.com/repos/alphagov/whitehall/labels/wip",
+        "name" => "wip",
+        "color" => "fbca04",
+      },
     ]
   end
 
   let(:expected_open_prs) do
     [
       {
-        title: '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host',
-        link: 'https://github.com/alphagov/whitehall/pull/2266',
-        author: 'mattbostock',
-        repo: 'whitehall',
+        title: "[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host",
+        link: "https://github.com/alphagov/whitehall/pull/2266",
+        author: "mattbostock",
+        repo: "whitehall",
         comments_count: 1,
         thumbs_up: 1,
         approved: false,
-        updated: Date.parse('2015-07-13 ((2457217j,0s,0n),+0s,2299161j)'),
+        updated: Date.parse("2015-07-13 ((2457217j,0s,0n),+0s,2299161j)"),
         labels: [],
       },
 
       {
-        title: 'Remove all Import-related code',
-        link: 'https://github.com/alphagov/whitehall-rebuild/pull/2248',
-        author: 'tekin',
-        repo: 'whitehall-rebuild',
+        title: "Remove all Import-related code",
+        link: "https://github.com/alphagov/whitehall-rebuild/pull/2248",
+        author: "tekin",
+        repo: "whitehall-rebuild",
         comments_count: 5,
         thumbs_up: 0,
         approved: true,
-        updated: Date.parse('2015-07-17 ((2457221j,0s,0n),+0s,2299161j)'),
-        labels: labels,
-      }
+        updated: Date.parse("2015-07-17 ((2457221j,0s,0n),+0s,2299161j)"),
+        labels:,
+      },
     ]
   end
 
@@ -73,53 +73,50 @@ RSpec.describe GithubFetcher do
 
   let(:pull_2266) do
     double(Sawyer::Resource,
-           user: double(Sawyer::Resource, login: 'mattbostock'),
-           title: '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host',
-           html_url: 'https://github.com/alphagov/whitehall/pull/2266',
+           user: double(Sawyer::Resource, login: "mattbostock"),
+           title: "[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host",
+           html_url: "https://github.com/alphagov/whitehall/pull/2266",
            number: 2266,
            review_comments: 1,
            comments: 0,
-           updated_at: '2015-07-13 01:00:44 UTC'
-          )
+           updated_at: "2015-07-13 01:00:44 UTC")
   end
 
   let(:pull_2248) do
     double(Sawyer::Resource,
-           user: double(Sawyer::Resource, login: 'tekin'),
-           title: 'Remove all Import-related code',
-           html_url: 'https://github.com/alphagov/whitehall-rebuild/pull/2248',
+           user: double(Sawyer::Resource, login: "tekin"),
+           title: "Remove all Import-related code",
+           html_url: "https://github.com/alphagov/whitehall-rebuild/pull/2248",
            number: 2248,
            review_comments: 1,
            comments: 4,
-           updated_at: '2015-07-17 01:00:44 UTC'
-          )
+           updated_at: "2015-07-17 01:00:44 UTC")
   end
 
   let(:pull_2295) do
     double(Sawyer::Resource,
-           user: double(Sawyer::Resource, login: 'lauramipsum'),
-           title: 'Enable ssh key signing',
-           html_url: 'https://github.com/alphagov/whitehall-security/pull/2295',
+           user: double(Sawyer::Resource, login: "lauramipsum"),
+           title: "Enable ssh key signing",
+           html_url: "https://github.com/alphagov/whitehall-security/pull/2295",
            number: 2295,
            review_comments: 0,
            comments: 0,
-           updated_at: '2015-07-17 01:00:44 UTC'
-          )
+           updated_at: "2015-07-17 01:00:44 UTC")
   end
 
   let(:comments_2266) do
     [
       "You should add more seal images on the front end",
       "Sure! I have done it now",
-      "LGTM :+1:"
-    ].map { |body| double(Sawyer::Resource, body: body)}
+      "LGTM :+1:",
+    ].map { |body| double(Sawyer::Resource, body:) }
   end
 
   let(:comments_2248) do
     [
       "Could you embed a seal song?",
-      "Sure! Please send me the recording"
-    ].map { |body| double(Sawyer::Resource, body: body)}
+      "Sure! Please send me the recording",
+    ].map { |body| double(Sawyer::Resource, body:) }
   end
 
   let(:comments_2295) do
@@ -128,7 +125,7 @@ RSpec.describe GithubFetcher do
 
   let(:reviews_2248) do
     [
-      double(Sawyer::Resource, state: "APPROVED" )
+      double(Sawyer::Resource, state: "APPROVED"),
     ]
   end
 
@@ -140,33 +137,36 @@ RSpec.describe GithubFetcher do
 
   before do
     allow(Octokit::Client).to receive(:new).and_return(fake_octokit_client)
-    allow(fake_octokit_client).to receive_message_chain('user.login')
+    allow(fake_octokit_client).to receive_message_chain("user.login")
     allow(fake_octokit_client).to receive(:auto_paginate=).with(false)
     response = double(items: [pull_2266, pull_2248, pull_2295])
-    allow(fake_octokit_client).to receive(:search_issues).with("is:pr state:open user:alphagov archived:false -is:draft", per_page: 100).and_return(response)
+    allow(fake_octokit_client).to receive(:search_issues).with(
+      "is:pr state:open user:alphagov archived:false -is:draft", per_page: 100
+    ).and_return(response)
     allow(fake_octokit_client).to receive(:last_response).and_return(double(data: response, rels: { next: nil }))
 
     allow(fake_octokit_client).to receive(:issue_comments).with(whitehall_repo_name, 2266).and_return(comments_2266)
-    allow(fake_octokit_client).to receive(:issue_comments).with(whitehall_rebuild_repo_name, 2248).and_return(comments_2248)
+    allow(fake_octokit_client).to receive(:issue_comments).with(whitehall_rebuild_repo_name,
+                                                                2248).and_return(comments_2248)
 
     allow(fake_octokit_client).to receive(:pull_request).with(whitehall_rebuild_repo_name, 2248).and_return(pull_2248)
     allow(fake_octokit_client).to receive(:pull_request).with(whitehall_repo_name, 2266).and_return(pull_2266)
 
-    allow(fake_octokit_client).to receive(:get).with(%r"repos/alphagov/[\w-]+/pulls/2248/reviews").and_return(reviews_2248)
-    allow(fake_octokit_client).to receive(:get).with(%r"repos/alphagov/[\w-]+/pulls/2266/reviews").and_return(reviews_2266)
+    allow(fake_octokit_client).to receive(:get).with(%r{repos/alphagov/[\w-]+/pulls/2248/reviews}).and_return(reviews_2248)
+    allow(fake_octokit_client).to receive(:get).with(%r{repos/alphagov/[\w-]+/pulls/2266/reviews}).and_return(reviews_2266)
   end
 
-  shared_examples_for 'fetching from GitHub' do
-    describe '#list_pull_requests' do
+  shared_examples_for "fetching from GitHub" do
+    describe "#list_pull_requests" do
       it "displays open pull requests open on the team's repos" do
         expect(github_fetcher.list_pull_requests).to match expected_open_prs
       end
     end
 
-    describe '#pull_requests_from_github' do
+    describe "#pull_requests_from_github" do
       it "returns an empty array when there are no items returned from search" do
         allow(fake_octokit_client).to receive(:last_response).and_return(
-          double(data: double(items: []), rels: { next: nil })
+          double(data: double(items: []), rels: { next: nil }),
         )
 
         expect(github_fetcher.pull_requests_from_github).to eq([])
@@ -183,119 +183,123 @@ RSpec.describe GithubFetcher do
     end
   end
 
-  context 'labels turned on' do
+  context "labels turned on" do
     let(:use_labels) { true }
     let(:labels) { blocked_and_wip }
 
     before do
-      allow(fake_octokit_client).to receive(:labels_for_issue).with(whitehall_rebuild_repo_name, 2248).and_return(blocked_and_wip)
+      allow(fake_octokit_client).to receive(:labels_for_issue).with(whitehall_rebuild_repo_name,
+                                                                    2248).and_return(blocked_and_wip)
       allow(fake_octokit_client).to receive(:labels_for_issue).with(whitehall_repo_name, 2266).and_return([])
       allow(fake_octokit_client).to receive(:labels_for_issue).with(whitehall_security_repo_name, 2295).and_return([])
     end
 
-    context 'excluding nothing' do
-      it_behaves_like 'fetching from GitHub'
+    context "excluding nothing" do
+      it_behaves_like "fetching from GitHub"
     end
 
     context 'excluding "designer" label' do
-      let(:exclude_labels) { ['designer'] }
+      let(:exclude_labels) { %w[designer] }
 
-      it_behaves_like 'fetching from GitHub'
+      it_behaves_like "fetching from GitHub"
     end
 
     context 'excluding "WIP" label' do
-      let(:exclude_labels) { ['WIP'] }
+      let(:exclude_labels) { %w[WIP] }
 
-      it 'filters out the WIP' do
-        expect(titles).not_to include('Remove all Import-related code')
-        expect(titles).to include('[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host')
+      it "filters out the WIP" do
+        expect(titles).not_to include("Remove all Import-related code")
+        expect(titles).to include("[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host")
       end
     end
 
     context 'excluding "wip" label' do
-      let(:exclude_labels) { ['wip'] }
+      let(:exclude_labels) { %w[wip] }
 
-      it 'filters out the wip' do
-        expect(titles).not_to include('Remove all Import-related code')
-        expect(titles).to include('[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host')
+      it "filters out the wip" do
+        expect(titles).not_to include("Remove all Import-related code")
+        expect(titles).to include("[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host")
       end
     end
 
     context 'excluding "whitehall-rebuild" repo' do
-      let(:repos) { ['whitehall-rebuild'] }
+      let(:repos) { %w[whitehall-rebuild] }
 
       it 'filters out PRs NOT from the "whitehall-rebuild" repo' do
-        expect(titles).to match_array(['Remove all Import-related code'])
+        expect(titles).to match_array(["Remove all Import-related code"])
       end
     end
   end
 
-  context 'labels turned off' do
+  context "labels turned off" do
     let(:use_labels) { false }
 
-    it_behaves_like 'fetching from GitHub'
-    context 'title exclusions' do
-      context 'excluding no titles' do
-        it_behaves_like 'fetching from GitHub'
+    it_behaves_like "fetching from GitHub"
+    context "title exclusions" do
+      context "excluding no titles" do
+        it_behaves_like "fetching from GitHub"
       end
 
       context 'excluding "BLAH BLAH BLAH" title' do
-        let(:exclude_titles) { ['BLAH BLAH BLAH'] }
+        let(:exclude_titles) { ["BLAH BLAH BLAH"] }
 
-        it_behaves_like 'fetching from GitHub'
+        it_behaves_like "fetching from GitHub"
       end
 
       context 'excluding "DISCUSSION" title' do
-        let(:exclude_titles) { ['FOR DISCUSSION ONLY'] }
+        let(:exclude_titles) { ["FOR DISCUSSION ONLY"] }
 
-        it 'filters out the DISCUSSION' do
-          expect(titles).not_to include('[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host')
-          expect(titles).to include('Remove all Import-related code')
+        it "filters out the DISCUSSION" do
+          expect(titles).not_to include("[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host")
+          expect(titles).to include("Remove all Import-related code")
         end
       end
 
       context 'excluding "discussion" title' do
-        let(:exclude_titles) { ['for discussion only'] }
+        let(:exclude_titles) { ["for discussion only"] }
 
-        it 'filters out the discussion' do
-          expect(titles).not_to include('[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host')
-          expect(titles).to include('Remove all Import-related code')
+        it "filters out the discussion" do
+          expect(titles).not_to include("[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host")
+          expect(titles).to include("Remove all Import-related code")
         end
       end
     end
   end
 
-  context 'with github team configured' do
-
+  context "with github team configured" do
     let(:use_labels) { false }
-    let(:github_team) { 'whitehall-security-devs' }
+    let(:github_team) { "whitehall-security-devs" }
 
     let(:github_team_repos) do
       [
-        double(Sawyer::Resource, name: "whitehall-security" )
+        double(Sawyer::Resource, name: "whitehall-security"),
       ]
     end
 
     before do
       allow(fake_octokit_client).to receive(:get).with("/orgs/#{ENV['SEAL_ORGANISATION']}/teams/#{github_team}/repos").and_return(github_team_repos)
-      allow(fake_octokit_client).to receive(:issue_comments).with(whitehall_security_repo_name, 2295).and_return(comments_2295)
-      allow(fake_octokit_client).to receive(:pull_request).with(whitehall_security_repo_name, 2295).and_return(pull_2295)
-      allow(fake_octokit_client).to receive(:get).with(%r"repos/alphagov/[\w-]+/pulls/2295/reviews").and_return(reviews_2295)
+      allow(fake_octokit_client).to receive(:issue_comments).with(whitehall_security_repo_name,
+                                                                  2295).and_return(comments_2295)
+      allow(fake_octokit_client).to receive(:pull_request).with(whitehall_security_repo_name,
+                                                                2295).and_return(pull_2295)
+      allow(fake_octokit_client).to receive(:get).with(%r{repos/alphagov/[\w-]+/pulls/2295/reviews}).and_return(reviews_2295)
     end
-     
-    context 'without repos configured' do
+
+    context "without repos configured" do
       let(:repos) { [] }
 
-      it 'only shows PRs for repos owned by the github team' do
+      it "only shows PRs for repos owned by the github team" do
         expect(titles).to match_array(["Enable ssh key signing"])
       end
     end
-     
-    context 'with repos configured' do
-      let(:repos) { ['whitehall', 'whitehall-rebuild'] }
 
-      it 'shows PRs for repos owned by the github team and the additional configured repos' do
-        expect(titles).to match_array(["Enable ssh key signing","Remove all Import-related code","[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host"])
+    context "with repos configured" do
+      let(:repos) { %w[whitehall whitehall-rebuild] }
+
+      it "shows PRs for repos owned by the github team and the additional configured repos" do
+        expect(titles).to match_array(["Enable ssh key signing",
+                                       "Remove all Import-related code",
+                                       "[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host"])
       end
     end
   end

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe GithubFetcher do
       use_labels: use_labels,
       exclude_labels: exclude_labels,
       exclude_titles: exclude_titles,
-      exclude_repos: exclude_repos,
-      include_repos: include_repos,
+      repos: repos,
     )
   }
 
@@ -68,8 +67,7 @@ RSpec.describe GithubFetcher do
 
   let(:exclude_labels) { nil }
   let(:exclude_titles) { nil }
-  let(:exclude_repos) { nil }
-  let(:include_repos) { nil }
+  let(:repos) { nil }
 
   let(:github_team) { nil }
 
@@ -224,15 +222,7 @@ RSpec.describe GithubFetcher do
     end
 
     context 'excluding "whitehall-rebuild" repo' do
-      let(:exclude_repos) { ['whitehall-rebuild'] }
-
-      it 'filters out PRs for the "whitehall-rebuild" repo' do
-        expect(titles).to match_array(['[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host'])
-      end
-    end
-
-    context 'excluding "whitehall-rebuild" repo' do
-      let(:include_repos) { ['whitehall-rebuild'] }
+      let(:repos) { ['whitehall-rebuild'] }
 
       it 'filters out PRs NOT from the "whitehall-rebuild" repo' do
         expect(titles).to match_array(['Remove all Import-related code'])
@@ -272,14 +262,6 @@ RSpec.describe GithubFetcher do
           expect(titles).to include('Remove all Import-related code')
         end
       end
-
-      context 'excluding "whitehall-rebuild" repo' do
-        let(:exclude_repos) { ['whitehall-rebuild'] }
-
-        it 'filters out PRs for the "whitehall-rebuild" repo' do
-          expect(titles).to match_array(['[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host'])
-        end
-      end
     end
   end
 
@@ -301,16 +283,16 @@ RSpec.describe GithubFetcher do
       allow(fake_octokit_client).to receive(:get).with(%r"repos/alphagov/[\w-]+/pulls/2295/reviews").and_return(reviews_2295)
     end
      
-    context 'without include_repos configured' do
-      let(:include_repos) { [] }
+    context 'without repos configured' do
+      let(:repos) { [] }
 
       it 'only shows PRs for repos owned by the github team' do
         expect(titles).to match_array(["Enable ssh key signing"])
       end
     end
      
-    context 'with include_repos configured' do
-      let(:include_repos) { ['whitehall', 'whitehall-rebuild'] }
+    context 'with repos configured' do
+      let(:repos) { ['whitehall', 'whitehall-rebuild'] }
 
       it 'shows PRs for repos owned by the github team and the additional configured repos' do
         expect(titles).to match_array(["Enable ssh key signing","Remove all Import-related code","[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host"])

--- a/spec/message_builder_spec.rb
+++ b/spec/message_builder_spec.rb
@@ -1,22 +1,22 @@
-require 'spec_helper'
-require './lib/message_builder'
+require "spec_helper"
+require "./lib/message_builder"
 
 RSpec.describe MessageBuilder do
   let(:team) { double(:team, compact: false) }
-  let(:github_fetcher) { double(:github_fetcher, list_pull_requests: pull_requests)}
+  let(:github_fetcher) { double(:github_fetcher, list_pull_requests: pull_requests) }
   subject(:message_builder) { MessageBuilder.new(team) }
 
   let(:no_unapproved_pull_requests) do
     [
       {
-        title: 'Some approved PR',
-        link: 'https://github.com/alphagov/whitehall/pull/9999',
-        author: 'helpful_person',
-        repo: 'whitehall',
+        title: "Some approved PR",
+        link: "https://github.com/alphagov/whitehall/pull/9999",
+        author: "helpful_person",
+        repo: "whitehall",
         comments_count: 5,
         thumbs_up: 0,
         approved: true,
-        updated: Date.parse('2015-07-17 ((2457221j, 0s, 0n), +0s, 2299161j)'),
+        updated: Date.parse("2015-07-17 ((2457221j, 0s, 0n), +0s, 2299161j)"),
         labels: [],
       },
     ]
@@ -25,25 +25,25 @@ RSpec.describe MessageBuilder do
   let(:recent_pull_requests) do
     [
       {
-        title: 'Remove all Import-related code',
-        link: 'https://github.com/alphagov/whitehall/pull/2248',
-        author: 'tekin',
-        repo: 'whitehall',
+        title: "Remove all Import-related code",
+        link: "https://github.com/alphagov/whitehall/pull/2248",
+        author: "tekin",
+        repo: "whitehall",
         comments_count: 5,
         thumbs_up: 0,
         approved: false,
-        updated: Date.parse('2015-07-17 ((2457221j, 0s, 0n), +0s, 2299161j)'),
+        updated: Date.parse("2015-07-17 ((2457221j, 0s, 0n), +0s, 2299161j)"),
         labels: [],
       },
       {
-        title: 'Some approved PR',
-        link: 'https://github.com/alphagov/whitehall/pull/9999',
-        author: 'helpful_person',
-        repo: 'whitehall',
+        title: "Some approved PR",
+        link: "https://github.com/alphagov/whitehall/pull/9999",
+        author: "helpful_person",
+        repo: "whitehall",
         comments_count: 5,
         thumbs_up: 0,
         approved: true,
-        updated: Date.parse('2015-07-17 ((2457221j, 0s, 0n), +0s, 2299161j)'),
+        updated: Date.parse("2015-07-17 ((2457221j, 0s, 0n), +0s, 2299161j)"),
         labels: [],
       },
     ]
@@ -52,125 +52,125 @@ RSpec.describe MessageBuilder do
   let(:old_and_new_pull_requests) do
     [
       {
-        title: '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host',
-        link: 'https://github.com/alphagov/whitehall/pull/2266',
-        author: 'mattbostock',
-        repo: 'whitehall',
+        title: "[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host",
+        link: "https://github.com/alphagov/whitehall/pull/2266",
+        author: "mattbostock",
+        repo: "whitehall",
         comments_count: 1,
         thumbs_up: 1,
         approved: false,
-        updated: Date.parse('2015-07-13 ((2457217j, 0s, 0n), +0s, 2299161j)'),
+        updated: Date.parse("2015-07-13 ((2457217j, 0s, 0n), +0s, 2299161j)"),
         labels: [],
       },
       {
-        title: 'Remove all Import-related code',
-        link: 'https://github.com/alphagov/whitehall/pull/2248',
-        author: 'tekin',
-        repo: 'whitehall',
+        title: "Remove all Import-related code",
+        link: "https://github.com/alphagov/whitehall/pull/2248",
+        author: "tekin",
+        repo: "whitehall",
         comments_count: 5,
         thumbs_up: 0,
         approved: false,
-        updated: Date.parse('2015-07-17 ((2457221j, 0s, 0n), +0s, 2299161j)'),
+        updated: Date.parse("2015-07-17 ((2457221j, 0s, 0n), +0s, 2299161j)"),
         labels: [],
       },
       {
-        title: 'Add extra examples to the specs',
-        link: 'https://github.com/alphagov/seal/pull/9999',
-        author: 'elliotcm',
-        repo: 'seal',
+        title: "Add extra examples to the specs",
+        link: "https://github.com/alphagov/seal/pull/9999",
+        author: "elliotcm",
+        repo: "seal",
         comments_count: 5,
         thumbs_up: 0,
         approved: false,
-        updated: Date.parse('2015-07-17 ((2457221j, 0s, 0n), +0s, 2299161j)'),
+        updated: Date.parse("2015-07-17 ((2457221j, 0s, 0n), +0s, 2299161j)"),
         labels: [],
       },
     ]
   end
 
   before do
-    Timecop.freeze(Time.local(2015, 07, 18))
+    Timecop.freeze(Time.local(2015, 0o7, 18))
 
     allow(GithubFetcher).to receive(:new).with(team).and_return(github_fetcher)
   end
 
-  context 'with labels' do
-    let(:mood) { 'informative' }
+  context "with labels" do
+    let(:mood) { "informative" }
     let(:pull_requests) do
       [
         {
-          title: 'My WIP',
-          link: 'https://github.com/org/repo/pull/42',
-          author: 'Agatha Christie',
-          repo: 'repo',
+          title: "My WIP",
+          link: "https://github.com/org/repo/pull/42",
+          author: "Agatha Christie",
+          repo: "repo",
           comments_count: 0,
           thumbs_up: 0,
           approved: false,
           updated: Date.today,
           labels: [
-            { 'name' => 'wip' },
-            { 'name' => 'blocked' }
+            { "name" => "wip" },
+            { "name" => "blocked" },
           ],
         },
       ]
     end
 
-    it 'includes the labels in the built message' do
+    it "includes the labels in the built message" do
       expect(message_builder.build.text).to include(
-        '[wip] [blocked] <https://github.com/org/repo/pull/42|My WIP> - 0 comments'
+        "[wip] [blocked] <https://github.com/org/repo/pull/42|My WIP> - 0 comments",
       )
     end
   end
 
-  context 'pull requests are recent' do
+  context "pull requests are recent" do
     let(:pull_requests) { recent_pull_requests }
 
-    it 'builds informative message excluding approved PRs' do
+    it "builds informative message excluding approved PRs" do
       expect(message_builder.build.text).to eq("Hello team!\n\nHere are the pull requests that need to be reviewed today:\n\n1) *whitehall* | tekin | updated yesterday\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\nMerry reviewing!")
     end
 
-    it 'has an informative poster mood' do
+    it "has an informative poster mood" do
       expect(message_builder.build.mood).to eq("informative")
     end
   end
 
-  context 'no unapproved pull requests' do
+  context "no unapproved pull requests" do
     let(:pull_requests) { no_unapproved_pull_requests }
 
-    it 'builds seal of approval message' do
+    it "builds seal of approval message" do
       expect(message_builder.build.text).to eq("Aloha team! It's a beautiful day! :happyseal: :happyseal: :happyseal:\n\nNo pull requests to review today! :rainbow: :sunny: :metal: :tada:")
     end
 
-    it 'has an approval poster mood' do
+    it "has an approval poster mood" do
       expect(message_builder.build.mood).to eq("approval")
     end
   end
 
-  context 'there are some PRs that are over 2 days old' do
-    let(:mood) { 'angry' }
+  context "there are some PRs that are over 2 days old" do
+    let(:mood) { "angry" }
     let(:pull_requests) { old_and_new_pull_requests }
 
     context "and some recent ones" do
-      before { Timecop.freeze(Time.local(2015, 07, 18)) }
-      it 'builds message' do
+      before { Timecop.freeze(Time.local(2015, 0o7, 18)) }
+      it "builds message" do
         expect(message_builder.build.text).to eq("AAAAAAARGH! This pull request has not been updated in over 2 days.\n\n1) *whitehall* | mattbostock | updated 5 days ago | 1 :+1:\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n\nRemember each time you forget to review your pull requests, a baby seal dies.\n\n\nThere are also these pull requests that need to be reviewed today:\n\n1) *whitehall* | tekin | updated yesterday\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n2) *seal* | elliotcm | updated yesterday\n<https://github.com/alphagov/seal/pull/9999|Add extra examples to the specs> - 5 comments")
       end
     end
 
     context "but no recent ones" do
-      before { Timecop.freeze(Time.local(2015, 07, 16)) }
-      it 'builds message' do
+      before { Timecop.freeze(Time.local(2015, 0o7, 16)) }
+      it "builds message" do
         expect(message_builder.build.text).to eq("AAAAAAARGH! This pull request has not been updated in over 2 days.\n\n1) *whitehall* | mattbostock | updated 3 days ago | 1 :+1:\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n\nRemember each time you forget to review your pull requests, a baby seal dies.\n\n\nThere are also these pull requests that need to be reviewed today:\n\n1) *whitehall* | tekin | updated -1 days ago\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n2) *seal* | elliotcm | updated -1 days ago\n<https://github.com/alphagov/seal/pull/9999|Add extra examples to the specs> - 5 comments")
       end
     end
 
-    it 'has an angry poster mood' do
+    it "has an angry poster mood" do
       expect(message_builder.build.mood).to eq("angry")
     end
 
     context "when in compact mode" do
       let(:team) { double(:team, compact: true) }
 
-      before { Timecop.freeze(Time.local(2015, 07, 18)) }
+      before { Timecop.freeze(Time.local(2015, 0o7, 18)) }
 
       it "builds a more compact message" do
         expect(message_builder.build.text).to eq("*Old pull requests*:\n1) whitehall: <https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host>\n\n*Recent pull requests*:\n1) whitehall: <https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code>\n2) seal: <https://github.com/alphagov/seal/pull/9999|Add extra examples to the specs>")
@@ -178,37 +178,37 @@ RSpec.describe MessageBuilder do
     end
   end
 
-  context 'rotting' do
+  context "rotting" do
     let(:pull_request) do
       {
-        title: '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host',
-        link: 'https://github.com/alphagov/whitehall/pull/2266',
-        author: 'mattbostock',
-        repo: 'whitehall',
-        comments_count: '1',
-        thumbs_up: '0',
-        updated: Date.parse('2015-07-13 ((2457217j,0s,0n),+0s,2299161j)'),
+        title: "[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host",
+        link: "https://github.com/alphagov/whitehall/pull/2266",
+        author: "mattbostock",
+        repo: "whitehall",
+        comments_count: "1",
+        thumbs_up: "0",
+        updated: Date.parse("2015-07-13 ((2457217j,0s,0n),+0s,2299161j)"),
       }
     end
 
     let(:pull_requests) { [pull_request] }
 
-    context 'old PR' do
+    context "old PR" do
       before do
-        Timecop.freeze(Time.local(2015, 07, 16))
+        Timecop.freeze(Time.local(2015, 0o7, 16))
       end
 
-      it 'is rotten' do
+      it "is rotten" do
         expect(message_builder).to be_rotten(pull_request)
       end
     end
 
-    context 'recent PR' do
+    context "recent PR" do
       before do
-        Timecop.freeze(Time.local(2015, 07, 15))
+        Timecop.freeze(Time.local(2015, 0o7, 15))
       end
 
-      it 'is not rotten' do
+      it "is not rotten" do
         expect(message_builder).to_not be_rotten(pull_request)
       end
     end

--- a/spec/seal_spec.rb
+++ b/spec/seal_spec.rb
@@ -5,17 +5,17 @@ require_relative "../lib/team"
 RSpec.describe Seal do
   subject(:seal) { described_class.new(teams) }
 
-  let(:lions) {
+  let(:lions) do
     Team.new(
       slack_channel: "#lions",
       quotes: ["go lions!"],
     )
-  }
-  let(:tigers) {
+  end
+  let(:tigers) do
     Team.new(
       slack_channel: "#tigers",
     )
-  }
+  end
   let(:teams) do
     [
       lions,

--- a/spec/slack_poster_spec.rb
+++ b/spec/slack_poster_spec.rb
@@ -4,33 +4,33 @@ require_relative "../lib/slack_poster"
 RSpec.describe SlackPoster do
   subject(:slack_poster) { described_class.new(team_channel, mood) }
 
-  let(:webhook_url) { 'https://slack/webhook' }
-  let(:team_channel) { '#angry-seal-bot-test' }
-  let(:message) { 'test running!' }
-  let(:mood) { 'informative' }
+  let(:webhook_url) { "https://slack/webhook" }
+  let(:team_channel) { "#angry-seal-bot-test" }
+  let(:message) { "test running!" }
+  let(:mood) { "informative" }
   let(:fake_slack_poster) { instance_double(Slack::Poster) }
 
   before do
     ENV["SLACK_WEBHOOK"] = webhook_url
   end
 
-  context 'send_request' do
+  context "send_request" do
     before do
       expect(Slack::Poster).to receive(:new).and_return(fake_slack_poster)
-      Timecop.freeze(Time.local(2015, 07, 16))
+      Timecop.freeze(Time.local(2015, 0o7, 16))
     end
 
-    it 'posts to Slack' do
+    it "posts to Slack" do
       expect(fake_slack_poster).to receive(:send_message).with(message).and_return(:ok)
       expect(slack_poster.send_request(message)).to be :ok
     end
   end
 
-  context 'create_poster' do
-    context 'on a regular day' do
+  context "create_poster" do
+    context "on a regular day" do
       before do
         expect(Slack::Poster).to receive(:new).and_return(fake_slack_poster)
-        Timecop.freeze(Time.local(2015, 07, 16))
+        Timecop.freeze(Time.local(2015, 0o7, 16))
       end
 
       it "posts as Informative Seal" do
@@ -39,7 +39,7 @@ RSpec.describe SlackPoster do
       end
     end
 
-    context 'within a week of Halloween' do
+    context "within a week of Halloween" do
       before do
         expect(Slack::Poster).to receive(:new).and_return(fake_slack_poster)
         Timecop.freeze(Time.local(2015, 10, 28))
@@ -55,10 +55,10 @@ RSpec.describe SlackPoster do
       end
     end
 
-    context 'within a month of Festive Season' do
+    context "within a month of Festive Season" do
       before do
         expect(Slack::Poster).to receive(:new).and_return(fake_slack_poster)
-        Timecop.freeze(Time.local(2015, 12, 01))
+        Timecop.freeze(Time.local(2015, 12, 0o1))
       end
 
       it "knows it is Festive Season" do
@@ -72,10 +72,10 @@ RSpec.describe SlackPoster do
     end
   end
 
-  context 'bad mood' do
-    let(:mood) { 'baadf00d' }
+  context "bad mood" do
+    let(:mood) { "baadf00d" }
 
-    it 'emits a meaningful error' do
+    it "emits a meaningful error" do
       expect { slack_poster }.to raise_error(RuntimeError, /Bad mood: baadf00d/)
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,13 +15,12 @@
 # The `.rspec` file also contains a few flags that are not defaults but that
 # users commonly want.
 #
-require 'timecop'
+require "timecop"
 require "pry-byebug"
 
-ENV['SEAL_ORGANISATION'] ||= "alphagov"
+ENV["SEAL_ORGANISATION"] ||= "alphagov"
 
 RSpec.configure do |config|
-
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`
     # and `failure_message` of custom matchers include text for helper methods
@@ -46,48 +45,46 @@ RSpec.configure do |config|
     Timecop.return
   end
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # These two settings work together to allow you to limit a spec run
-  # to individual examples or groups you care about by tagging them with
-  # `:focus` metadata. When nothing is tagged with `:focus`, all examples
-  # get run.
-  config.filter_run :focus
-  config.run_all_when_everything_filtered = true
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
-  #   - http://teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://myronmars.to/n/dev-blog/2014/05/notable-changes-in-rspec-3#new__config_option_to_disable_rspeccore_monkey_patching
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = 'doc'
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # These two settings work together to allow you to limit a spec run
+  #   # to individual examples or groups you care about by tagging them with
+  #   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
+  #   # get run.
+  #   config.filter_run :focus
+  #   config.run_all_when_everything_filtered = true
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
+  #   #   - http://teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://myronmars.to/n/dev-blog/2014/05/notable-changes-in-rspec-3#new__config_option_to_disable_rspeccore_monkey_patching
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = 'doc'
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end

--- a/spec/team_builder_spec.rb
+++ b/spec/team_builder_spec.rb
@@ -79,8 +79,7 @@ RSpec.describe TeamBuilder do
     expect(tigers.use_labels).to eq(false)
     expect(tigers.compact).to eq(false)
     expect(tigers.quotes).to eq([])
-    expect(tigers.include_repos).to eq([])
-    expect(tigers.exclude_repos).to eq([])
+    expect(tigers.repos).to eq([])
   end
 
   it "allows the overriding of options via environment variables" do

--- a/spec/team_builder_spec.rb
+++ b/spec/team_builder_spec.rb
@@ -9,37 +9,38 @@ RSpec.describe TeamBuilder do
 
   before do
     FileUtils.mkdir_p(File.join(File.dirname(__FILE__), "../config"))
-    File.write(File.join(File.dirname(__FILE__), "../config/#{organisation}.yml"), YAML.dump(
-      "lions" => {
-        "channel" => "#lions",
-        "exclude_titles" => [
-          "DO NOT MERGE",
-          "WIP",
-        ],
-        "exclude_labels" => [
-          "DO NOT MERGE",
-          "WIP",
-        ],
-        "use_labels" => true,
-        "compact" => true,
-        "quotes" => [
-          "This is a quote",
-          "This is also a quote",
-        ],
-      },
-      "tigers" => {
-        "channel" => "#tigers",
-      },
-      "cats" => {
-        "github_team" => "cat-coding-club",
-        "channel" => "#cats",
-      },
-    ))
+    File.write(File.join(File.dirname(__FILE__), "../config/#{organisation}.yml"),
+               YAML.dump(
+                 "lions" => {
+                   "channel" => "#lions",
+                   "exclude_titles" => [
+                     "DO NOT MERGE",
+                     "WIP",
+                   ],
+                   "exclude_labels" => [
+                     "DO NOT MERGE",
+                     "WIP",
+                   ],
+                   "use_labels" => true,
+                   "compact" => true,
+                   "quotes" => [
+                     "This is a quote",
+                     "This is also a quote",
+                   ],
+                 },
+                 "tigers" => {
+                   "channel" => "#tigers",
+                 },
+                 "cats" => {
+                   "github_team" => "cat-coding-club",
+                   "channel" => "#cats",
+                 },
+               ))
   end
 
-  let(:env) { {"SEAL_ORGANISATION" => organisation} }
+  let(:env) { { "SEAL_ORGANISATION" => organisation } }
 
-  let(:teams) { TeamBuilder.build(env: env) }
+  let(:teams) { TeamBuilder.build(env:) }
 
   it "loads each team from the static config file" do
     expect(teams.count).to eq(3)
@@ -47,32 +48,23 @@ RSpec.describe TeamBuilder do
   end
 
   it "loads all keys" do
-    lions = teams.find {|t| t.channel == "#lions"}
-    cats = teams.find {|t| t.channel == "#cats"}
+    lions = teams.find { |t| t.channel == "#lions" }
+    cats = teams.find { |t| t.channel == "#cats" }
 
-    expect(lions.exclude_titles).to eq([
-      "DO NOT MERGE",
-      "WIP",
-    ])
+    expect(lions.exclude_titles).to eq(["DO NOT MERGE", "WIP"])
 
-    expect(lions.exclude_labels).to eq([
-      "DO NOT MERGE",
-      "WIP",
-    ])
+    expect(lions.exclude_labels).to eq(["DO NOT MERGE", "WIP"])
 
     expect(lions.use_labels).to eq(true)
     expect(lions.compact).to eq(true)
 
-    expect(lions.quotes).to eq([
-      "This is a quote",
-      "This is also a quote",
-    ])
+    expect(lions.quotes).to eq(["This is a quote", "This is also a quote"])
 
     expect(cats.github_team).to eq("cat-coding-club")
   end
 
   it "provides sensible defaults" do
-    tigers = teams.find {|t| t.channel == "#tigers"}
+    tigers = teams.find { |t| t.channel == "#tigers" }
 
     expect(tigers.exclude_titles).to eq([])
     expect(tigers.exclude_labels).to eq([])
@@ -86,19 +78,19 @@ RSpec.describe TeamBuilder do
     env.merge!("GITHUB_EXCLUDE_LABELS" => "new,labels")
 
     teams.each do |team|
-      expect(team.exclude_labels).to eq(["new", "labels"])
+      expect(team.exclude_labels).to eq(%w[new labels])
     end
   end
 
   it "allows the selection of a single team" do
-    teams = TeamBuilder.build(env: env, team_name: "tigers")
+    teams = TeamBuilder.build(env:, team_name: "tigers")
 
     expect(teams.count).to eq(1)
     expect(teams.first.channel).to eq("#tigers")
   end
 
   it "short-circuits if the team name does not appear in the configuration file" do
-    teams = TeamBuilder.build(env: env, team_name: "cheetas")
+    teams = TeamBuilder.build(env:, team_name: "cheetas")
 
     expect(teams.count).to eq(0)
   end

--- a/spec/team_builder_spec.rb
+++ b/spec/team_builder_spec.rb
@@ -11,11 +11,6 @@ RSpec.describe TeamBuilder do
     FileUtils.mkdir_p(File.join(File.dirname(__FILE__), "../config"))
     File.write(File.join(File.dirname(__FILE__), "../config/#{organisation}.yml"), YAML.dump(
       "lions" => {
-        "members" => [
-          "lil lion",
-          "snoop lion",
-          "biggy smalls",
-        ],
         "channel" => "#lions",
         "exclude_titles" => [
           "DO NOT MERGE",
@@ -33,11 +28,6 @@ RSpec.describe TeamBuilder do
         ],
       },
       "tigers" => {
-        "members" => [
-          "tony",
-          "stripey",
-          "biggy smalls",
-        ],
         "channel" => "#tigers",
       },
       "cats" => {
@@ -59,12 +49,6 @@ RSpec.describe TeamBuilder do
   it "loads all keys" do
     lions = teams.find {|t| t.channel == "#lions"}
     cats = teams.find {|t| t.channel == "#cats"}
-
-    expect(lions.members).to eq([
-      "lil lion",
-      "snoop lion",
-      "biggy smalls",
-    ])
 
     expect(lions.exclude_titles).to eq([
       "DO NOT MERGE",

--- a/templates/no_pull_requests.compact.text.erb
+++ b/templates/no_pull_requests.compact.text.erb
@@ -1,0 +1,3 @@
+Aloha team! It's a beautiful day! :happyseal: :happyseal: :happyseal:
+
+No pull requests to review today! :rainbow: :sunny: :metal: :tada:


### PR DESCRIPTION
## What

Change the seal behaviour to surface PRs raised against *repos owned by the team*, rather than its current behaviour of surfacing PRs raised by team members.

i.e. if a developer is in the Foo team, the Foo team is currently notified of all that developer's PRs regardless of which repos those PRs are in. Instead, we want the Seal to show PRs for repos owned by the team, so if the Foo team owns the Bar repo, it will be notified of all PRs to that repo regardless of who raised the PR.

## Why

Developers have agreed this will be useful - see [poll](https://gds.slack.com/archives/CAB4Q3QBW/p1660639759673839).

Some benefits:

1) It gives teams better visibility of their own repos
2) It prevents 'bulk PR noise', e.g. when a Platform Reliability dev raises Ruby upgrade PRs for repos outside of our team, we get reminded of those PRs constantly, even though it's up to the other teams to review/test/merge said PRs.

[Trello](https://trello.com/c/Pdh7bs59/2971-change-seal-to-post-via-team-repo-ownership-rather-than-who-raised-pr-3)