### PR TITLE
Remove GitHub teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ export GITHUB_TOKEN="get_your_github_token_from_yourgithub_settings"
 export GITHUB_API_ENDPOINT="your_github_api_endpoint" # OPTIONAL If you are using a Github Enterprise instance
 export SLACK_WEBHOOK="get_your_incoming_webhook_link_for_your_slack_group_channel"
 export SLACK_CHANNEL="#whatever-channel-you-prefer"
-export GITHUB_TEAM="your-team-name-on-github"
 export GITHUB_USE_LABELS=true
 export GITHUB_EXCLUDE_LABELS="[DO NOT MERGE],Don't merge,DO NOT MERGE,Waiting on factcheck,wip"
 export GITHUB_REPOS="myapp,anotherrepo" # Repos you want to be notified about
@@ -111,7 +110,6 @@ docker run -it --rm --name seal \
   -e SLACK_WEBHOOK=${SLACK_WEBHOOK} \
   -e DYNO=${DYNO} \
   -e SLACK_CHANNEL=${SLACK_CHANNEL} \
-  -e GITHUB_TEAM=${GITHUB_TEAM} \
   -e GITHUB_USE_LABELS=${GITHUB_USE_LABELS} \
   -e "GITHUB_EXCLUDE_LABELS=${GITHUB_EXCLUDE_LABELS}" \
   -e "SEAL_QUOTES=${SEAL_QUOTES}" \

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -215,7 +215,6 @@ govuk-forms:
     - PARKED
     - PROTOTYPE
     - WIP
-  github_team: forms-devs
 
 govuk-frontenders:
   channel: '#govuk-frontenders'
@@ -387,7 +386,6 @@ govuk-replatforming:
     - PARKED
     - PROTOTYPE
     - WIP
-  github_team: gov-uk-replatforming
   repos:
     - govuk-helm-charts
     - govuk-infrastructure

--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -11,7 +11,7 @@ class GithubFetcher
     @exclude_labels = team.exclude_labels.map(&:downcase).uniq
     @exclude_titles = team.exclude_titles.map(&:downcase).uniq
     @labels = {}
-    @repos = get_team_repos(team.github_team, team.repos)
+    @repos = team.repos
   end
 
   def list_pull_requests
@@ -92,16 +92,5 @@ private
 
   def excluded_title?(title)
     exclude_titles.any? { |t| title.downcase.include?(t) }
-  end
-
-  def get_team_repos(team_slug, repos)
-    return repos if team_slug.nil?
-
-    github_team_repos = get_github_team_repos(team_slug)
-    (github_team_repos + repos).uniq
-  end
-
-  def get_github_team_repos(team_slug)
-    github.get("/orgs/#{@organisation}/teams/#{team_slug}/repos").map(&:name)
   end
 end

--- a/lib/team.rb
+++ b/lib/team.rb
@@ -1,6 +1,5 @@
 class Team
   def initialize(
-    github_team: nil,
     use_labels: nil,
     compact: nil,
     exclude_labels: nil,
@@ -9,7 +8,6 @@ class Team
     quotes: nil,
     slack_channel: nil
   )
-    @github_team = github_team
     @use_labels = (use_labels.nil? ? false : use_labels)
     @compact = (compact.nil? ? false : compact)
     @exclude_labels = exclude_labels || []
@@ -20,7 +18,6 @@ class Team
   end
 
   attr_reader(*%i[
-    github_team
     use_labels
     compact
     exclude_labels

--- a/lib/team_builder.rb
+++ b/lib/team_builder.rb
@@ -38,7 +38,6 @@ private
 
   def apply_env(config)
     {
-      github_team: env["GITHUB_TEAM"] || config["github_team"],
       use_labels: env["GITHUB_USE_LABELS"] == "true" || config["use_labels"],
       compact: env["COMPACT"] == "true" || config["compact"],
       exclude_labels: env["GITHUB_EXCLUDE_LABELS"]&.split(",") || config["exclude_labels"],

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -4,7 +4,6 @@ require_relative "../lib/github_fetcher"
 RSpec.describe GithubFetcher do
   let(:team) do
     Team.new(
-      github_team:,
       use_labels:,
       exclude_labels:,
       exclude_titles:,
@@ -62,8 +61,6 @@ RSpec.describe GithubFetcher do
   let(:exclude_labels) { nil }
   let(:exclude_titles) { nil }
   let(:repos) { %w[whitehall govuk-docker content-store] }
-
-  let(:github_team) { nil }
 
   let(:pull_2266) do
     double(Sawyer::Resource,
@@ -231,44 +228,6 @@ RSpec.describe GithubFetcher do
       it "filters out the DISCUSSION" do
         expect(titles).not_to include("[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host")
         expect(titles).to include("Remove all Import-related code")
-      end
-    end
-  end
-
-  context "with github team configured" do
-    let(:use_labels) { false }
-    let(:github_team) { "content-store-devs" }
-
-    let(:github_team_repos) do
-      [
-        double(Sawyer::Resource, name: "content-store"),
-      ]
-    end
-
-    before do
-      allow(fake_octokit_client).to receive(:get).with("/orgs/#{ENV['SEAL_ORGANISATION']}/teams/#{github_team}/repos").and_return(github_team_repos)
-      allow(fake_octokit_client).to receive(:issue_comments).with(content_store_repo_name,
-                                                                  2295).and_return(comments_2295)
-      allow(fake_octokit_client).to receive(:pull_request).with(content_store_repo_name,
-                                                                2295).and_return(pull_2295)
-      allow(fake_octokit_client).to receive(:get).with(%r{repos/alphagov/[\w-]+/pulls/2295/reviews}).and_return(reviews_2295)
-    end
-
-    context "without repos configured" do
-      let(:repos) { [] }
-
-      it "only shows PRs for repos owned by the github team" do
-        expect(titles).to match_array(["Enable ssh key signing"])
-      end
-    end
-
-    context "with repos configured" do
-      let(:repos) { %w[whitehall govuk-docker] }
-
-      it "shows PRs for repos owned by the github team and the additional configured repos" do
-        expect(titles).to match_array(["Enable ssh key signing",
-                                       "Remove all Import-related code",
-                                       "[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host"])
       end
     end
   end

--- a/spec/message_builder_spec.rb
+++ b/spec/message_builder_spec.rb
@@ -152,14 +152,14 @@ RSpec.describe MessageBuilder do
     context "and some recent ones" do
       before { Timecop.freeze(Time.local(2015, 0o7, 18)) }
       it "builds message" do
-        expect(message_builder.build.text).to eq("AAAAAAARGH! This pull request has not been updated in over 2 days.\n\n1) *whitehall* | mattbostock | updated 5 days ago | 1 :+1:\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n\nRemember each time you forget to review your pull requests, a baby seal dies.\n\n\nThere are also these pull requests that need to be reviewed today:\n\n1) *whitehall* | tekin | updated yesterday\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n2) *seal* | elliotcm | updated yesterday\n<https://github.com/alphagov/seal/pull/9999|Add extra examples to the specs> - 5 comments")
+        expect(message_builder.build.text).to eq("AAAAAAARGH! This pull request has not been updated in over 2 days.\n\n1) *whitehall* | mattbostock | updated 5 days ago | 1 :+1:\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n\n\nThere are also these pull requests that need to be reviewed today:\n\n1) *whitehall* | tekin | updated yesterday\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n2) *seal* | elliotcm | updated yesterday\n<https://github.com/alphagov/seal/pull/9999|Add extra examples to the specs> - 5 comments")
       end
     end
 
     context "but no recent ones" do
       before { Timecop.freeze(Time.local(2015, 0o7, 16)) }
       it "builds message" do
-        expect(message_builder.build.text).to eq("AAAAAAARGH! This pull request has not been updated in over 2 days.\n\n1) *whitehall* | mattbostock | updated 3 days ago | 1 :+1:\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n\nRemember each time you forget to review your pull requests, a baby seal dies.\n\n\nThere are also these pull requests that need to be reviewed today:\n\n1) *whitehall* | tekin | updated -1 days ago\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n2) *seal* | elliotcm | updated -1 days ago\n<https://github.com/alphagov/seal/pull/9999|Add extra examples to the specs> - 5 comments")
+        expect(message_builder.build.text).to eq("AAAAAAARGH! This pull request has not been updated in over 2 days.\n\n1) *whitehall* | mattbostock | updated 3 days ago | 1 :+1:\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n\n\nThere are also these pull requests that need to be reviewed today:\n\n1) *whitehall* | tekin | updated -1 days ago\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n2) *seal* | elliotcm | updated -1 days ago\n<https://github.com/alphagov/seal/pull/9999|Add extra examples to the specs> - 5 comments")
       end
     end
 

--- a/spec/team_builder_spec.rb
+++ b/spec/team_builder_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe TeamBuilder do
                    "channel" => "#tigers",
                  },
                  "cats" => {
-                   "github_team" => "cat-coding-club",
                    "channel" => "#cats",
                  },
                ))
@@ -59,8 +58,6 @@ RSpec.describe TeamBuilder do
     expect(lions.compact).to eq(true)
 
     expect(lions.quotes).to eq(["This is a quote", "This is also a quote"])
-
-    expect(cats.github_team).to eq("cat-coding-club")
   end
 
   it "provides sensible defaults" do

--- a/templates/old_pull_requests.text.erb
+++ b/templates/old_pull_requests.text.erb
@@ -2,8 +2,6 @@ AAAAAAARGH! <%= these(old_pull_requests.length) %> <%= pr_plural(old_pull_reques
 
 <%= @angry_bark %>
 
-Remember each time you forget to review your pull requests, a baby seal dies.
-
 <% if recent_pull_requests.any? %>
 There are also these pull requests that need to be reviewed today:
 


### PR DESCRIPTION
This does not work after the latest changes to Seal (https://github.com/alphagov/seal/pull/333)
Trello card: https://trello.com/c/Pdh7bs59/2971-change-seal-to-post-via-team-repo-ownership-rather-than-who-raised-pr-3