### PR TITLE
Rephrase recent pull requests

### DIFF
--- a/spec/message_builder_spec.rb
+++ b/spec/message_builder_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe MessageBuilder do
       before { Timecop.freeze(Time.local(2015, 0o7, 18)) }
 
       it "builds a more compact message" do
-        expect(message_builder.build.text).to eq("*Old pull requests*:\n1) whitehall: <https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host>\n\n*Recent pull requests*:\n1) whitehall: <https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code>\n2) seal: <https://github.com/alphagov/seal/pull/9999|Add extra examples to the specs>")
+        expect(message_builder.build.text).to eq("*Old pull requests*:\n1) whitehall: <https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host>\n\n*Pull requests with recent activity*:\n1) whitehall: <https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code>\n2) seal: <https://github.com/alphagov/seal/pull/9999|Add extra examples to the specs>")
       end
     end
   end

--- a/templates/list_pull_requests.compact.text.erb
+++ b/templates/list_pull_requests.compact.text.erb
@@ -1,2 +1,2 @@
-*Recent pull requests*:
+*Pull requests with recent activity*:
 <%= @message %>

--- a/templates/old_pull_requests.compact.text.erb
+++ b/templates/old_pull_requests.compact.text.erb
@@ -1,6 +1,6 @@
 *Old pull requests*:
 <%= @angry_bark %>
 <% if !@recent_pull_requests.empty? %>
-*Recent pull requests*:
+*Pull requests with recent activity*:
 <%= @list_recent_pull_requests %>
 <% end %>


### PR DESCRIPTION
Leaving a comment on old PRs will move it to the "Recent pull requests" list, this commit rephrases that to make it more accurate.