### PR TITLE
Fetch repo name from base

### DIFF
--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -45,7 +45,7 @@ private
               :github
 
   def present_pull_request(pull_request)
-    repo = pull_request.head.repo.name
+    repo = pull_request.base.repo.name
 
     {
       title: pull_request.title,

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe GithubFetcher do
            comments: 0,
            updated_at: "2015-07-13 01:00:44 UTC",
            draft: false,
-           head: double(Sawyer::Resource, repo: double(Sawyer::Resource, name: "whitehall")),
+           base: double(Sawyer::Resource, repo: double(Sawyer::Resource, name: "whitehall")),
            labels: [
              { name: "wip" },
            ])
@@ -88,7 +88,7 @@ RSpec.describe GithubFetcher do
            comments: 4,
            updated_at: "2015-07-17 01:00:44 UTC",
            draft: false,
-           head: double(Sawyer::Resource, repo: double(Sawyer::Resource, name: "govuk-docker")),
+           base: double(Sawyer::Resource, repo: double(Sawyer::Resource, name: "govuk-docker")),
            labels: [])
   end
 
@@ -102,7 +102,7 @@ RSpec.describe GithubFetcher do
            comments: 0,
            updated_at: "2015-07-17 01:00:44 UTC",
            draft: false,
-           head: double(Sawyer::Resource, repo: double(Sawyer::Resource, name: "content-store")),
+           base: double(Sawyer::Resource, repo: double(Sawyer::Resource, name: "content-store")),
            labels: [])
   end
 


### PR DESCRIPTION
When getting the repo name from a PR's 'head' it will break when it's a fork with a different name. This changes Seal to look at base, which should always be the correct repo name.

This is the PR that was causing the error: https://api.github.com/repos/alphagov/pay-frontend/pulls/2309

Trello: https://trello.com/c/WegbOTst/2999-investigate-why-seal-is-broken-for-govuk-pay