### PR TITLE
Update slack-poster and other dependencies.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,11 @@ source "https://rubygems.org"
 
 ruby File.read(".ruby-version").chomp
 
+gem "faraday-retry"
 gem "octokit", "~> 5.6"
 gem "rubocop-govuk", require: false
 gem "sinatra"
-gem "slack-poster", "~> 1.0.1"
+gem "slack-poster", "~> 2.2.2"
 gem "thin"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,9 +20,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.0)
-    httparty (0.16.4)
-      mime-types (~> 3.0)
-      multi_xml (>= 0.5.2)
+    faraday-retry (2.0.0)
+      faraday (~> 2.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.2)
@@ -30,11 +29,7 @@ GEM
       oj (~> 3)
       optimist (~> 3)
     method_source (1.0.0)
-    mime-types (3.3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0225)
     minitest (5.16.3)
-    multi_xml (0.6.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     octokit (5.6.1)
@@ -108,8 +103,8 @@ GEM
       rack (~> 2.2, >= 2.2.4)
       rack-protection (= 3.0.2)
       tilt (~> 2.0)
-    slack-poster (1.0.1)
-      httparty (~> 0.12)
+    slack-poster (2.2.2)
+      faraday (>= 1.0.0)
     thin (1.8.1)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -125,6 +120,7 @@ PLATFORMS
 
 DEPENDENCIES
   fakefs
+  faraday-retry
   jsonlint
   octokit (~> 5.6)
   pry-byebug
@@ -132,7 +128,7 @@ DEPENDENCIES
   rspec
   rubocop-govuk
   sinatra
-  slack-poster (~> 1.0.1)
+  slack-poster (~> 2.2.2)
   thin
   timecop
 
@@ -140,4 +136,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.1.4
+   2.3.23

--- a/lib/seal.rb
+++ b/lib/seal.rb
@@ -1,5 +1,8 @@
 #!/usr/bin/env ruby
 
+require "bundler/setup"
+Bundler.require(:default)
+
 require_relative "message_builder"
 require_relative "slack_poster"
 

--- a/lib/slack_poster.rb
+++ b/lib/slack_poster.rb
@@ -1,5 +1,3 @@
-require "slack-poster"
-
 class SlackPoster
   attr_accessor :webhook_url, :poster, :mood, :mood_hash, :channel, :season_name, :halloween_season, :festive_season
 


### PR DESCRIPTION
- slack-poster 1.0.1 -> 2.2.2 and fix Bundler load path issues.
- Include faraday-retry to suppress message on startup about it being missing 🙄
- Update bundler to get rid of `Calling DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call DidYouMean.correct_error(error_name, spell_checker)' instead.` message when running the tests.

Everything apart from the `lib/seal.rb` change was generated with `bundle update` and `bundle update --bundler`.

Tests (`bundle exec rake`) pass locally.