### PR TITLE
Add repos back in for Navigation and Presentation

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -472,6 +472,18 @@ interaction-and-personalisation-govuk:
 navigation-and-presentation-govuk:
   channel: '#navigation-and-presentation-govuk'
   compact: true
+  repos:
+    - authenticating-proxy
+    - bouncer
+    - cache-clearing-service
+    - collections
+    - frontend
+    - government-frontend
+    - info-frontend
+    - router
+    - router-api
+    - service-manual-frontend
+    - static
   exclude_titles:
     - DNM
     - DO NOT MERGE


### PR DESCRIPTION
We were under the impression that the team name matching in the Developer Docs would pull out our list of repos. This has been broken since we took our list of repos out.