### PR TITLE
Mapit and mapit-scripts now retired.

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -336,8 +336,6 @@ govuk-platform-reliability:
     - govuk_test
     - icinga_slack_webhook
     - locations-api
-    - mapit
-    - mapit-scripts
     - packager
     - plek
     - puppet-gor


### PR DESCRIPTION
https://trello.com/c/LMRiT7yz/1581-retire-mapit-and-mapit-scripts