### PR TITLE
Remove side-by-side-browser from publishing-platform

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -405,7 +405,6 @@ govuk-publishing-platform:
     - link-checker-api
     - optic14n
     - publishing-api
-    - side-by-side-browser
     - sidekiq-monitoring
     - signon
     - transition


### PR DESCRIPTION
Trello: https://trello.com/c/rv3f6V9H/378-retire-side-by-side-browser

The application is being retired.