### PR TITLE
remove reference to govuk-content-schemas

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -396,7 +396,6 @@ govuk-publishing-platform:
     - govspeak
     - govspeak-preview
     - govuk-content-api-docs
-    - govuk-content-schemas
     - govuk_message_queue_consumer
     - govuk_schemas
     - govuk_sidekiq


### PR DESCRIPTION
Schemas have now been moved into publishing api.

[Trello](https://trello.com/c/ZUK2duYI/361-add-govuk-content-schemas-to-publishing-api-repo)