### PR TITLE
Remove govuk-dependencies repo

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -316,7 +316,6 @@ govuk-platform-reliability:
     - govuk-aws
     - govuk-aws-data
     - govuk-cdn-config
-    - govuk-dependencies
     - govuk-dependency-checker
     - govuk-deploy-lag-badger
     - govuk-dns


### PR DESCRIPTION
We have archived that repo.

https://trello.com/c/Vl80xssv/3046-archive-govuk-dependencies