### PR TITLE
Get GOV.UK team repos from Developer Docs repos.json

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,4 +16,5 @@ group :test do
   gem "rake"
   gem "rspec"
   gem "timecop"
+  gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,8 @@ GEM
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
+    crack (0.4.5)
+      rexml
     daemons (1.4.1)
     diff-lcs (1.5.0)
     eventmachine (1.2.7)
@@ -22,6 +24,7 @@ GEM
     faraday-net_http (3.0.2)
     faraday-retry (2.0.0)
       faraday (~> 2.0)
+    hashdiff (1.0.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.2)
@@ -114,6 +117,10 @@ GEM
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.3.0)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   ruby
@@ -131,6 +138,7 @@ DEPENDENCIES
   slack-poster (~> 2.2.2)
   thin
   timecop
+  webmock
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Fork the repo and add/change the config files that relate to your github organis
 
 Include your team's name, repos and the Slack channel you want to post to.
 
+> If your team is part of the GOV.UK programme, you do not need to add a list of repos to config/alphagov.yml.
+> The [Developer docs repos.json](https://docs.publishing.service.gov.uk/repos.json) is now the single source of truth for information about GOV.UK repositories and which team is responsible for them.
+
 In your shell profile, put in:
 
 ```sh
@@ -55,7 +58,8 @@ In your forked repo, include your team names in the appropriate bash script. Ex.
 
 ### Local testing
 
-To test the script locally, go to Slack and create a channel or private group called "#angry-seal-bot-test" (the Slack webhook you set up should have its channel set to "#angry-seal-bot-test" in the Integration Settings). Then run `./bin/seal.rb your_team_name bot_animal` in your command line, and you should see the post in the #angry-seal-bot-test channel.
+To test the script, create a private Slack channel e.g. "#angry-seal-bot-test-abc" and update `@team_channel` on [this line in slack_poster.rb](https://github.com/alphagov/seal/blob/main/lib/slack_poster.rb#L120) to the one you created (also remove the `if` statement).
+Then log in to Heroku (credentials can be found in [govuk-secrets](https://github.com/alphagov/govuk-secrets)) and under the "Deploy" tab, you can deploy your branch which should be in the drop down list of branches in the "Manual deploy" section. Under the "More" drop down located in the top right, select "Run console" where you can run `./bin/seal.rb your_team_name`, and you should see the post in your test channel (assuming you have included it in the list of teams in [morning_seal.sh](https://github.com/alphagov/seal/blob/main/bin/morning_seal.sh)).
 
 If you don't want to post github pull requests but a random quote from your team's quotes config, run `./bin/seal.rb your_team_name quotes`
 

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -161,15 +161,6 @@ govuk-datagovuk:
     - PARKED
     - PROTOTYPE
     - WIP
-  repos:
-    - ckan-functional-tests
-    - ckan-mock-harvest-sources
-    - ckanext-datagovuk
-    - datagovuk-tech-docs
-    - datagovuk_find
-    - datagovuk_publish
-    - datagovuk_publish_elasticsearch_monitor
-    - datagovuk_reference
 
 govuk-developers:
   channel: '#govuk-developers'
@@ -180,16 +171,6 @@ govuk-developers:
     - PARKED
     - PROTOTYPE
     - WIP
-  repos:
-    - govuk-browser-extension
-    - govuk-connect
-    - govuk-developer-docs
-    - govuk-docker
-    - govuk-ithc-documentation
-    - govuk-rfcs
-    - govuk-rota-announcer
-    - govuk-user-reviewer
-    - slimmer
 
 govuk-forms:
   channel: '#govuk-forms-tech'
@@ -217,9 +198,6 @@ govuk-frontenders:
     - PARKED
     - PROTOTYPE
     - WIP
-  repos:
-    - govuk_publishing_components
-    - stylelint-config-gds
 
 govuk-green-team:
   channel: '#govuk-green-team'
@@ -310,46 +288,6 @@ govuk-platform-reliability:
     - Try with each bit of work to upskill others
     - It's okay to spend some time understanding the thing(s) before implementing the solution
     - It's OK to pick up and work on something you don't understand yet
-  repos:
-    - bulk-merger
-    - content-data-admin
-    - content-data-api
-    - gds_zendesk
-    - govuk-app-deployment
-    - govuk-aws
-    - govuk-aws-data
-    - govuk-cdn-config
-    - govuk-dependency-checker
-    - govuk-deploy-lag-badger
-    - govuk-dns
-    - govuk-jenkinslib
-    - govuk-lambda-app-deployment
-    - govuk-load-testing
-    - govuk-paas-office-ip-router
-    - govuk-pact-broker
-    - govuk-puppet
-    - govuk-repo-mirror
-    - govuk-saas-config
-    - govuk-secondline-blinken
-    - govuk-secrets
-    - govuk-sentry-monitor
-    - govuk-zendesk-display-screen
-    - govuk_app_config
-    - govuk_crawler_worker
-    - govuk_seed_crawler
-    - govuk_test
-    - icinga_slack_webhook
-    - packager
-    - plek
-    - puppet-gor
-    - rack-logstasher
-    - release
-    - rubocop-govuk
-    - seal
-    - smokey
-    - support
-    - support-api
-    - upgrade-ruby-version
 
 govuk-publishing-experience:
   channel: '#govuk-publishing-experience-tech'
@@ -361,23 +299,6 @@ govuk-publishing-experience:
     - PARKED
     - PROTOTYPE
     - WIP
-  repos:
-    - collections-publisher
-    - contacts-admin
-    - content-publisher
-    - content-tagger
-    - govuk_admin_template
-    - manuals-publisher
-    - maslow
-    - miller-columns-element
-    - paste-html-to-govspeak
-    - publisher
-    - service-manual-publisher
-    - short-url-manager
-    - special-route-publisher
-    - specialist-publisher
-    - travel-advice-publisher
-    - whitehall
 
 govuk-publishing-platform:
   channel: '#govuk-publishing-platform'
@@ -389,25 +310,6 @@ govuk-publishing-platform:
     - PARKED
     - PROTOTYPE
     - WIP
-  repos:
-    - asset-manager
-    - content-store
-    - gds-api-adapters
-    - gds-sso
-    - govspeak
-    - govspeak-preview
-    - govuk-content-api-docs
-    - govuk_message_queue_consumer
-    - govuk_schemas
-    - govuk_sidekiq
-    - hmrc-manuals-api
-    - link-checker-api
-    - optic14n
-    - publishing-api
-    - sidekiq-monitoring
-    - signon
-    - transition
-    - transition-config
 
 govuk-replatforming:
   channel: '#govuk-replatforming'
@@ -419,11 +321,6 @@ govuk-replatforming:
     - PARKED
     - PROTOTYPE
     - WIP
-  repos:
-    - govuk-helm-charts
-    - govuk-infrastructure
-    - govuk-kubernetes-cluster-user-docs
-    - govuk-ruby-images
 
 govwifi:
   channel: '#govwifi-monitoring'
@@ -469,18 +366,6 @@ interaction-and-personalisation-govuk:
 navigation-and-presentation-govuk:
   channel: '#navigation-and-presentation-govuk'
   compact: true
-  repos:
-    - authenticating-proxy
-    - bouncer
-    - cache-clearing-service
-    - collections
-    - frontend
-    - government-frontend
-    - info-frontend
-    - router
-    - router-api
-    - service-manual-frontend
-    - static
   exclude_titles:
     - DNM
     - DO NOT MERGE

--- a/lib/team_builder.rb
+++ b/lib/team_builder.rb
@@ -61,4 +61,10 @@ private
       end
     end
   end
+
+  def govuk_json
+    source = "https://docs.publishing.service.gov.uk/repos.json"
+    resp = Net::HTTP.get_response(URI.parse(source))
+    JSON.parse(resp.body)
+  end
 end

--- a/spec/team_builder_spec.rb
+++ b/spec/team_builder_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "fakefs/spec_helpers"
+require 'webmock/rspec'
 require_relative "../lib/team_builder"
 
 RSpec.describe TeamBuilder do
@@ -7,7 +8,16 @@ RSpec.describe TeamBuilder do
 
   let(:organisation) { "big_cats" }
 
+  let(:uri) { URI('https://docs.publishing.service.gov.uk/repos.json') }
+
+  let(:repos) {[{"app_name" => "Brazil", "team" => "#govuk-jaguars"},
+                {"app_name" => "rainforest", "team" => "#govuk-wildcats-team"},
+                {"app_name" => "savanna", "team" => "#govuk-wildcats-team"},
+                {"app_name" => "grassland", "team" => "#govuk-wildcats-team"}]}
+
   before do
+    stub_request(:get, uri).with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).to_return(status: 200, body: JSON.dump(repos), headers: {})
+
     FileUtils.mkdir_p(File.join(File.dirname(__FILE__), "../config"))
     File.write(File.join(File.dirname(__FILE__), "../config/#{organisation}.yml"),
                YAML.dump(

--- a/spec/team_builder_spec.rb
+++ b/spec/team_builder_spec.rb
@@ -37,6 +37,9 @@ RSpec.describe TeamBuilder do
                      "This is a quote",
                      "This is also a quote",
                    ],
+                   "repos" => [
+                     "Africa"
+                   ],
                  },
                  "tigers" => {
                    "channel" => "#tigers",
@@ -44,6 +47,12 @@ RSpec.describe TeamBuilder do
                  "cats" => {
                    "channel" => "#cats",
                  },
+                 "govuk-jaguars" => {
+                   "channel" => "#govuk-jaguars",
+                 },
+                 "govuk-wildcats" => {
+                   "channel" => "#govuk-wildcats-team",
+                 }
                ))
   end
 
@@ -52,8 +61,8 @@ RSpec.describe TeamBuilder do
   let(:teams) { TeamBuilder.build(env:) }
 
   it "loads each team from the static config file" do
-    expect(teams.count).to eq(3)
-    expect(teams.map(&:channel)).to match_array(["#lions", "#tigers", "#cats"])
+    expect(teams.count).to eq(5)
+    expect(teams.map(&:channel)).to match_array(["#lions", "#tigers", "#cats", "#govuk-jaguars", "#govuk-wildcats-team"])
   end
 
   it "loads all keys" do
@@ -79,6 +88,21 @@ RSpec.describe TeamBuilder do
     expect(tigers.compact).to eq(false)
     expect(tigers.quotes).to eq([])
     expect(tigers.repos).to eq([])
+  end
+
+  it "gets non gov.uk team repos from the static config file if repos array is defined" do
+    lions = teams.find { |t| t.channel == "#lions" }
+    expect(lions.repos).to eq(["Africa"])
+  end
+
+  it "gets gov.uk team repos from an external JSON file if repos array is not defined in static config file" do
+    jaguars = teams.find { |t| t.channel == "#govuk-jaguars" }
+    expect(jaguars.repos).to eq(["Brazil"])
+  end
+
+  it "gets gov.uk team repos from an external JSON file if repos array is not defined in static config file and team channel differs to team name" do
+    teams = TeamBuilder.build(env:, team_name: "govuk-wildcats")
+    expect(teams.first.repos).to eq(["rainforest", "savanna", "grassland"])
   end
 
   it "allows the overriding of options via environment variables" do


### PR DESCRIPTION
[repos.json](https://docs.publishing.service.gov.uk/repos.json) is used as the source of truth for gov.uk repositories and contains the most up to date list of repos each team is responsible for.

This PR includes some changes to the logic so that if a team does not contain a list of repos in the static config, they will be queried for in the data returned from repos.json.

This has also been tested by deploying this branch on Heroku and running `./bin/seal.rb team_name` in the console and ensuring the correct output is sent to a test Slack channel.

Trello card: https://trello.com/c/CW4FlVXn/3040-have-seal-check-dev-docs-for-repos-3