### PR TITLE
Change frontend notifications

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -192,7 +192,7 @@ govuk-forms:
     - forms-product-page
 
 govuk-frontenders:
-  channel: '#govuk-frontenders'
+  channel: '#govuk-publishing-components'
   exclude_titles:
     - DNM
     - DO NOT MERGE


### PR DESCRIPTION
## What
Trying to move notifications from the `#govuk-frontenders` channel to the newly created `#govuk-publishing-components` channel.

First time making a change here so feel free to point out if I've misunderstood or missed something.

## Why
The `#govuk-frontenders` channel has become a bit overwhelmed with notifications recently so we've created a new channel for them to go into.