### PR TITLE
GUA-401 rename di-authentication-account-mgt to di-account-mgt-frontend

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -151,7 +151,7 @@ govuk-accounts-tech:
     - WIP
   repos:
     - di-account-management-backend
-    - di-authentication-account-management
+    - di-account-management-frontend
     - di-accounts-infra
 
 govuk-datagovuk:


### PR DESCRIPTION
Why
Repository has been renamed to reflect it's separation from anything around authentication provision.

What
rename di-authentication-account-management to di-account-management-frontend