### PR TITLE
Change Seal to look at "days since undrafted" rather than "days since opened"

### DIFF
--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -58,6 +58,7 @@ private
       approved: approved?(pull_request, repo),
       updated: Date.parse(pull_request.updated_at.to_s),
       created: Date.parse(pull_request.created_at.to_s),
+      marked_ready_for_review_at: marked_ready_for_review_at(pull_request, repo)&.to_date,
       labels: labels(pull_request),
     }
   end
@@ -94,5 +95,10 @@ private
 
   def excluded_title?(title)
     exclude_titles.any? { |t| title.downcase.include?(t) }
+  end
+
+  def marked_ready_for_review_at(pull_request, repo)
+    events = github.get("repos/#{organisation}/#{repo}/issues/#{pull_request.number}/timeline")
+    events.filter { |e| e.event == "ready_for_review" }.map(&:created_at).sort.last
   end
 end

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe GithubFetcher do
         approved: false,
         created: Date.parse("2015-07-13 ((2457217j,0s,0n),+0s,2299161j)"),
         updated: Date.parse("2015-07-13 ((2457217j,0s,0n),+0s,2299161j)"),
+        marked_ready_for_review_at: nil,
         labels: wip_or_not,
       },
       {
@@ -43,6 +44,7 @@ RSpec.describe GithubFetcher do
         approved: true,
         created: Date.parse("2015-07-17 ((2457221j,0s,0n),+0s,2299161j)"),
         updated: Date.parse("2015-07-17 ((2457221j,0s,0n),+0s,2299161j)"),
+        marked_ready_for_review_at: nil,
         labels: [],
       },
       {
@@ -56,6 +58,7 @@ RSpec.describe GithubFetcher do
         title: "Enable ssh key signing",
         created: Date.parse("2015-07-17 ((2457221j,0s,0n),+0s,2299161j)"),
         updated: Date.parse("2015-07-17 ((2457221j,0s,0n),+0s,2299161j)"),
+        marked_ready_for_review_at: Date.new(2015, 7, 18),
       },
     ]
   end
@@ -140,6 +143,16 @@ RSpec.describe GithubFetcher do
 
   let(:reviews_2295) { [] }
 
+  let(:timeline_2248) { [] }
+
+  let(:timeline_2266) { [] }
+
+  let(:timeline_2295) do
+    [
+      double(Sawyer::Resource, created_at: Time.new(2015, 7, 18, 2, 0, 44, "UTC"), event: "ready_for_review")
+    ]
+  end
+
   let(:titles) { github_fetcher.list_pull_requests.map { |pr| pr[:title] } }
 
   let(:no_prs) { [] }
@@ -173,6 +186,10 @@ RSpec.describe GithubFetcher do
     allow(fake_octokit_client).to receive(:get).with(%r{repos/alphagov/[\w-]+/pulls/2248/reviews}).and_return(reviews_2248)
     allow(fake_octokit_client).to receive(:get).with(%r{repos/alphagov/[\w-]+/pulls/2266/reviews}).and_return(reviews_2266)
     allow(fake_octokit_client).to receive(:get).with(%r{repos/alphagov/[\w-]+/pulls/2295/reviews}).and_return(reviews_2295)
+
+    allow(fake_octokit_client).to receive(:get).with(%r{repos/alphagov/[\w-]+/issues/2248/timeline}).and_return(timeline_2248)
+    allow(fake_octokit_client).to receive(:get).with(%r{repos/alphagov/[\w-]+/issues/2266/timeline}).and_return(timeline_2266)
+    allow(fake_octokit_client).to receive(:get).with(%r{repos/alphagov/[\w-]+/issues/2295/timeline}).and_return(timeline_2295)
   end
 
   shared_examples_for "fetching from GitHub" do

--- a/spec/message_builder_spec.rb
+++ b/spec/message_builder_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe MessageBuilder do
     let(:pull_requests) { recent_pull_requests }
 
     it "builds informative message excluding approved PRs" do
-      expect(message_builder.build.text).to eq("Hello team!\n\nHere are the pull requests that need to be reviewed today:\n\n1) *whitehall* | tekin | created yesterday\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\nMerry reviewing!")
+      expect(message_builder.build.text).to eq("Hello team!\n\nHere are the pull requests that need to be reviewed today:\n\n1) *whitehall* | tekin | created/undrafted yesterday\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\nMerry reviewing!")
     end
 
     it "has an informative poster mood" do
@@ -152,14 +152,14 @@ RSpec.describe MessageBuilder do
     context "and some recent ones" do
       before { Timecop.freeze(Time.local(2015, 0o7, 18)) }
       it "builds message" do
-        expect(message_builder.build.text).to eq("AAAAAAARGH! This pull request is over 2 days old.\n\n1) *whitehall* | mattbostock | created 5 days ago | 1 :+1:\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n\n\nThere are also these pull requests that need to be reviewed today:\n\n1) *whitehall* | tekin | created yesterday\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n2) *seal* | elliotcm | created yesterday\n<https://github.com/alphagov/seal/pull/9999|Add extra examples to the specs> - 5 comments")
+        expect(message_builder.build.text).to eq("AAAAAAARGH! This pull request is over 2 days old.\n\n1) *whitehall* | mattbostock | created/undrafted 5 days ago | 1 :+1:\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n\n\nThere are also these pull requests that need to be reviewed today:\n\n1) *whitehall* | tekin | created/undrafted yesterday\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n2) *seal* | elliotcm | created/undrafted yesterday\n<https://github.com/alphagov/seal/pull/9999|Add extra examples to the specs> - 5 comments")
       end
     end
 
     context "but no recent ones" do
       before { Timecop.freeze(Time.local(2015, 0o7, 16)) }
       it "builds message" do
-        expect(message_builder.build.text).to eq("AAAAAAARGH! This pull request is over 2 days old.\n\n1) *whitehall* | mattbostock | created 3 days ago | 1 :+1:\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n\n\nThere are also these pull requests that need to be reviewed today:\n\n1) *whitehall* | tekin | created -1 days ago\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n2) *seal* | elliotcm | created -1 days ago\n<https://github.com/alphagov/seal/pull/9999|Add extra examples to the specs> - 5 comments")
+        expect(message_builder.build.text).to eq("AAAAAAARGH! This pull request is over 2 days old.\n\n1) *whitehall* | mattbostock | created/undrafted 3 days ago | 1 :+1:\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n\n\nThere are also these pull requests that need to be reviewed today:\n\n1) *whitehall* | tekin | created/undrafted -1 days ago\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n2) *seal* | elliotcm | created/undrafted -1 days ago\n<https://github.com/alphagov/seal/pull/9999|Add extra examples to the specs> - 5 comments")
       end
     end
 

--- a/spec/message_builder_spec.rb
+++ b/spec/message_builder_spec.rb
@@ -212,5 +212,28 @@ RSpec.describe MessageBuilder do
         expect(message_builder).to_not be_rotten(pull_request)
       end
     end
+
+    context "old PR recently marked ready for review" do
+      let(:pull_request) do
+        {
+          title: "[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host",
+          link: "https://github.com/alphagov/whitehall/pull/2266",
+          author: "mattbostock",
+          repo: "whitehall",
+          comments_count: "1",
+          thumbs_up: "0",
+          created: Date.new(2015, 6, 13),
+          marked_ready_for_review_at: Date.new(2015, 7, 13)
+        }
+      end
+
+      before do
+        Timecop.freeze(Time.local(2015, 7, 15))
+      end
+
+      it "is not rotten" do
+        expect(message_builder).to_not be_rotten(pull_request)
+      end
+    end
   end
 end

--- a/templates/_pull_request.text.erb
+++ b/templates/_pull_request.text.erb
@@ -1,2 +1,2 @@
-<%= @index %>) *<%= @pr[:repo] %>* | <%= @pr[:author] %> | created <%= [days_plural(@days), @thumbs_up, @approved].join %>
+<%= @index %>) *<%= @pr[:repo] %>* | <%= @pr[:author] %> | created/undrafted <%= [days_plural(@days), @thumbs_up, @approved].join %>
 <%= "#{labels(@pr)} " unless [nil, ""].include?(labels(@pr)) %><<%= @pr[:link] %>|<%= html_encode(@pr[:title]) %>> - <%= [@pr[:comments_count], comments(@pr)].join %>


### PR DESCRIPTION
[Trello card](https://trello.com/c/D3ZuNtp2/3109-change-seal-to-look-at-days-since-undrafted-rather-than-days-since-opened-2)

* Changes the Seal logic to look at the number of days since a PR was converted from draft PR to ‘real’ PR, when reporting on old pull requests.
* If a PR was created as a non-draft PR in the first instance, then falls back to looking at the days since the PR was opened.

I've updated the test suite to test this new logic, and also tested it locally against [this PR](https://github.com/alphagov/govuk-helm-charts/pull/916).