### PR TITLE
Update team name for Navigation and Homepage

### DIFF
--- a/bin/dependapanda.sh
+++ b/bin/dependapanda.sh
@@ -12,7 +12,7 @@ teams=(
   govuk-publishing-platform
   govuk-replatforming
   interaction-and-personalisation-govuk
-  navigation-and-presentation-govuk
+  navigation-and-homepage-govuk
   user-experience-measurement-govuk
 )
 

--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -14,7 +14,7 @@ teams=(
   govuk-replatforming
   govwifi
   interaction-and-personalisation-govuk
-  navigation-and-presentation-govuk
+  navigation-and-homepage-govuk
   user-experience-measurement-govuk
   dev-platform-team
 )
@@ -27,7 +27,7 @@ morning_quote_teams=(
   fun-workstream-govuk
   fun-workstream-gds-community
   govuk-green-team
-  navigation-and-presentation-govuk
+  navigation-and-homepage-govuk
   dev-platform-team
 )
 


### PR DESCRIPTION
We changed the team name in the config in here https://github.com/alphagov/seal/pull/409.
We need to update the name for dapendapanda and seal.