### PR TITLE
Add configurable quote posting days feature

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,6 +16,10 @@
     "GITHUB_API_ENDPOINT": {
       "description": "OPTIONAL. If you are using a Github Enterprise instance instead of public github.com i.e https://github.yourcompany.com/api/v3"
     },
+    "GITHUB_QUOTES_DAYS": {
+      "description": "What days of the week should the Seal post quotes",
+      "required": true
+    },
     "GITHUB_USE_LABELS": {
       "description": "Comma separated list of labels to include",
       "required": false

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -13,6 +13,12 @@ common_properties: &common_properties
     - DNM
     - DRAFT
     - PARKED
+  quotes_days:
+    - Monday
+    - Tuesday
+    - Wednesday
+    - Thursday
+    - Friday
 
 data-infrastructure:
   channel: '#data-infrastructure'
@@ -103,6 +109,10 @@ fun-workstream-gds-community:
     - <https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/how-gds-works/our-people/its-ok-to|It's ok to> ask for help
     - <https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/how-gds-works/our-people/its-ok-to|It's ok to> put yourself first
     - <https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/how-gds-works/our-people/its-ok-to|It's ok to> love what you do
+  quotes_days:
+    - Monday
+    - Wednesday
+    - Friday
 
 fun-workstream-govuk:
   channel: '#govuk'
@@ -136,6 +146,10 @@ fun-workstream-govuk:
     - <https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/how-gds-works/our-people/its-ok-to|It's ok to> ask for help
     - <https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/how-gds-works/our-people/its-ok-to|It's ok to> put yourself first
     - <https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/how-gds-works/our-people/its-ok-to|It's ok to> love what you do
+  quotes_days:
+    - Monday
+    - Wednesday
+    - Friday
 
 govuk-accounts:
   channel: '#govuk-accounts'

--- a/lib/seal.rb
+++ b/lib/seal.rb
@@ -26,7 +26,7 @@ class Seal
     begin
       message = case mode
                 when "quotes"
-                  Message.new(team.quotes.sample)
+                  Message.new(team.quotes.sample) if team.quotes_days.map(&:downcase).include?(Date.today.strftime("%A").downcase)
                 when "dependapanda"
                   MessageBuilder.new(team, :panda).build
                 else

--- a/lib/team.rb
+++ b/lib/team.rb
@@ -4,12 +4,14 @@ class Team
     compact: nil,
     exclude_labels: nil,
     exclude_titles: nil,
+    quotes_days: nil,
     repos: nil,
     quotes: nil,
     slack_channel: nil
   )
     @use_labels = (use_labels.nil? ? false : use_labels)
     @compact = (compact.nil? ? false : compact)
+    @quotes_days = quotes_days || []
     @exclude_labels = exclude_labels || []
     @exclude_titles = exclude_titles || []
     @repos = repos || []
@@ -19,6 +21,7 @@ class Team
 
   attr_reader(*%i[
     use_labels
+    quotes_days
     compact
     exclude_labels
     exclude_titles

--- a/lib/team_builder.rb
+++ b/lib/team_builder.rb
@@ -58,6 +58,7 @@ private
   def apply_env(config)
     {
       use_labels: env["GITHUB_USE_LABELS"] == "true" || config["use_labels"],
+      quotes_days: env["GITHUB_QUOTES_DAYS"]&.split(",") || config["quotes_days"],
       compact: env["COMPACT"] == "true" || config["compact"],
       exclude_labels: env["GITHUB_EXCLUDE_LABELS"]&.split(",") || config["exclude_labels"],
       exclude_titles: env["GITHUB_EXCLUDE_TITLES"]&.split(",") || config["exclude_titles"],

--- a/spec/team_builder_spec.rb
+++ b/spec/team_builder_spec.rb
@@ -37,6 +37,13 @@ RSpec.describe TeamBuilder do
                      "This is a quote",
                      "This is also a quote",
                    ],
+                   "quotes_days" => [
+                      "Monday",
+                      "Tuesday",
+                      "Wednesday",
+                      "Thursday",
+                      "Friday",
+                    ],
                    "repos" => [
                      "Africa"
                    ],


### PR DESCRIPTION
Adds a new feature that allows users to configure the days of the week when the Seal should post quotes.

Adding this by popular request as the Seal can be a bit too noisy for many people.

[Trello](https://trello.com/c/NyZnkqLy/3166-add-configurable-quote-posting-days-to-the-seal)