### PR TITLE
Fix channel name

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -359,7 +359,7 @@ govwifi:
     - govwifi-watchdog
 
 content-interactions-on-platform-govuk:
-  channel: '#tech-content-interactions-on-platform'
+  channel: '#tech-content-interactions-on-platform-govuk'
   compact: true
   <<: *common_properties
 


### PR DESCRIPTION

Fix channel name for Content Interactions on Platform (add missing -govuk)