### PR TITLE
Add new DI Orange repos

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -40,10 +40,14 @@ di-ipv-orange-cri-maintainers:
     - di-ipv-cri-common-express
     - di-ipv-cri-common-infrastructure
     - di-ipv-cri-common-lambdas
+    - di-ipv-cri-dev-tools
     - di-ipv-cri-kbv-api
     - di-ipv-cri-kbv-front
     - di-ipv-cri-lib
-    - di-ipv-cri-pipieline-deployment
+    - di-ipv-cri-pipeline-deployment
+    - di-ipv-cri-toy-api
+    - di-ipv-cri-toy-front
+
   security_alerts: false
 
 data-products:


### PR DESCRIPTION
Add new repos for:
- dev-tools
- toy-cri

Fix naming for:
- pipeline-deployment