### PR TITLE
Resolve the daily "Seal of Approval" in #govuk-publishing-components

### DIFF
--- a/bin/dependapanda.sh
+++ b/bin/dependapanda.sh
@@ -6,8 +6,8 @@ teams=(
   govuk-datagovuk
   govuk-developers
   govuk-forms
-  govuk-frontenders
   govuk-platform-security-reliability
+  govuk-publishing-components
   govuk-publishing-experience
   govuk-publishing-platform
   govuk-platform-engineering

--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -6,9 +6,9 @@ teams=(
   govuk-datagovuk
   govuk-developers
   govuk-forms
-  govuk-frontenders
   govuk-pay
   govuk-platform-security-reliability
+  govuk-publishing-components
   govuk-publishing-experience
   govuk-publishing-platform
   govuk-platform-engineering

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -232,6 +232,8 @@ govuk-forms:
 govuk-frontenders:
   channel: '#govuk-publishing-components'
   <<: *common_properties
+  repos:
+    - govuk_publishing_components
 
 govuk-green-team:
   channel: '#govuk-green-team'

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -229,7 +229,7 @@ govuk-forms:
     - forms-product-page
   security_alerts: false
 
-govuk-frontenders:
+govuk-publishing-components:
   channel: '#govuk-publishing-components'
   <<: *common_properties
   repos:


### PR DESCRIPTION
This config wasn't monitoring any repos so each day we'd get a "Seal of Approval" as it hadn't identified any PRs that needed review. This resolves this to watch the govuk_publishing_components repo.

It also changes the name of the team to govuk-publishing-components to better capture the grouping intent.