### PR TITLE
Move User Experience Measurement team notifications

### DIFF
--- a/bin/dependapanda.sh
+++ b/bin/dependapanda.sh
@@ -14,7 +14,7 @@ teams=(
   govuk-platform-engineering
   content-interactions-on-platform-govuk
   navigation-and-homepage-govuk
-  user-experience-measurement-govuk
+  user-experience-measurement-govuk-robot-invasion
 )
 
 for team in ${teams[*]}; do

--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -16,7 +16,7 @@ teams=(
   govwifi
   content-interactions-on-platform-govuk
   navigation-and-homepage-govuk
-  user-experience-measurement-govuk
+  user-experience-measurement-govuk-robot-invasion
   dev-platform-team
 )
 

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -387,10 +387,21 @@ navigation-and-homepage-govuk:
     - Is your work waiting to be reviewed? Make sure to ask someone.
     - Did you learn something cool recently? Share it with your fellow devs!
 
-user-experience-measurement-govuk:
-  channel: '#user-experience-measurement-govuk'
+user-experience-measurement-govuk-robot-invasion:
+  channel: '#user-experience-measurement-govuk-robot-invasion'
   compact: true
   <<: *common_properties
+quotes:
+    - What do you call a failed robot invasion? A botched invasion!
+    - What do you call a robot who likes to row? A row-bot!
+    - What’s the name of a robot’s favourite restaurant? Megabytes!
+    - What do robot dogs do? They byte!
+    - Why did the robot fail its exam? They were a bit rusty!
+    - What is a robot's favourite music? Heavy metal!
+    - What do robots eat for snacks? Micro chips!
+quotes_days:
+  - Monday
+  - Friday
 
 proj-early-talent-assigned-learning:
   channel: '#proj-early-talent-assigned-learning'


### PR DESCRIPTION
[Trello](https://trello.com/c/a5yl1un5/544-create-separate-uxm-slack-channel-dedicated-to-bots-move-bots-to-new-channel-and-remove-from-old-team-channel)

Moves UXM team notifications to a new Slack channel. The new channel is called 'user-experience-measurement-robot-invasion' and will just be for bot notifications. This is because our main channel was getting too noisy.