### PR TITLE
Add Publishing Access & Permissions team

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -339,6 +339,11 @@ govuk-publishing-platform:
   compact: true
   <<: *common_properties
 
+govuk-publishing-access-and-permissions:
+  channel: '#govuk-publishing-access-and-permissions-team'
+  compact: true
+  <<: *common_properties
+
 govuk-platform-engineering:
   channel: '#govuk-platform-engineering'
   compact: true


### PR DESCRIPTION
Question: Do I need to add a listed of owned repos as well? Or is that picked up from elsewhere? It looks as if some teams have a `repos` key defined, but others do not.