### PR TITLE
Fix moving UXM slack notifications

### DIFF
--- a/bin/dependapanda.sh
+++ b/bin/dependapanda.sh
@@ -14,7 +14,7 @@ teams=(
   govuk-platform-engineering
   content-interactions-on-platform-govuk
   navigation-and-homepage-govuk
-  user-experience-measurement-govuk-robot-invasion
+  user-experience-measurement-govuk
 )
 
 for team in ${teams[*]}; do

--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -16,7 +16,7 @@ teams=(
   govwifi
   content-interactions-on-platform-govuk
   navigation-and-homepage-govuk
-  user-experience-measurement-govuk-robot-invasion
+  user-experience-measurement-govuk
   dev-platform-team
 )
 
@@ -30,6 +30,7 @@ morning_quote_teams=(
   govuk-green-team
   navigation-and-homepage-govuk
   dev-platform-team
+  user-experience-measurement-govuk
 )
 
 for team in ${morning_quote_teams[*]}; do

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -394,7 +394,7 @@ navigation-and-homepage-govuk:
     - Is your work waiting to be reviewed? Make sure to ask someone.
     - Did you learn something cool recently? Share it with your fellow devs!
 
-user-experience-measurement-govuk-robot-invasion:
+user-experience-measurement-govuk:
   channel: '#user-experience-measurement-govuk-robot-invasion'
   compact: true
   <<: *common_properties


### PR DESCRIPTION
[Trello](https://trello.com/c/a5yl1un5/544-create-separate-uxm-slack-channel-dedicated-to-bots-move-bots-to-new-channel-and-remove-from-old-team-channel)

Fixed misconfiguration in a previous PR (https://github.com/alphagov/seal/commit/fbfa1ebe5c8062cdd03117a31fca919aa0018860). The `team` in this application [needs to match](https://github.com/alphagov/seal/blob/d3fc2b15b49c8ce4185c6ac621d7c1b40c5474ce/lib/team_builder.rb#L87) the team in the [dev docs](https://github.com/alphagov/govuk-developer-docs/blob/main/data/repos.yml#L270) so this has been fixed. I also added the team name to morning_quote_teams.