### PR TITLE
Add new repo to govuk-accounts bark list

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -177,6 +177,7 @@ govuk-accounts-tech:
     - di-account-management-backend
     - di-account-management-frontend
     - di-accounts-infra
+    - di-govuk-one-login-service-header
   security_alerts: false
 
 govuk-datagovuk:


### PR DESCRIPTION
Adds di-govuk-one-login-service-header to the list of repositories the Seal should bark at govuk-accounts-tech about.

**NB - this looked like a simple change and I can't run this code on my machine. So I haven't run any tests and am hoping this will just work. If this isn't appropriate, please let me know and one of the developers on my team can do this properly.**