### PR TITLE
Add a 60 second delay between Dependapanda teams

### DIFF
--- a/bin/dependapanda.sh
+++ b/bin/dependapanda.sh
@@ -20,4 +20,5 @@ teams=(
 
 for team in ${teams[*]}; do
   ./bin/seal_runner.rb $team dependapanda
+  sleep 60
 done


### PR DESCRIPTION
We are currently hitting a GitHub rate limit [1] of 30 requests per minute when looping through teams in the Dependapanda script.

Therefore adding a delay of one minute between each team to slow down the number of requests being made.

1: https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#rate-limit