### PR TITLE
Add a one-minute sleep between dependapanda teams to mitigate rate-limiting problem.

### DIFF
--- a/bin/dependapanda.sh
+++ b/bin/dependapanda.sh
@@ -20,4 +20,5 @@ teams=(
 
 for team in ${teams[*]}; do
   ./bin/seal_runner.rb $team dependapanda
+  sleep 60
 done


### PR DESCRIPTION

The Dependapanda slack is currently getting rate limited by Github API (possibly a combination of more teams and a lot of dependapanda issues at the moment). Add a 1 minute sleep in between teams to allow the rate counter to cool down.