### PR TITLE
Remove repo override for on platform team

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -337,11 +337,6 @@ govuk-publishing-on-platform-content:
   channel: '#govuk-publishing-on-platform-content-tech'
   compact: true
   <<: *common_properties
-  repos:
-    - publisher
-    - collections-publisher
-    - content-tagger
-    - smart-answers
 
 govuk-publishing-platform:
   channel: '#govuk-publishing-platform'


### PR DESCRIPTION
Will not be necessary as switching over smart answers to same team in dev docs - overriding the defaults is no longer required