### PR TITLE
Fix dependapanda & morning_seal for Publishing A&P

### DIFF
--- a/bin/dependapanda.sh
+++ b/bin/dependapanda.sh
@@ -7,7 +7,7 @@ teams=(
   govuk-developers
   govuk-forms
   govuk-platform-security-reliability
-  govuk-publishing-access-and-permissions-team
+  govuk-publishing-access-and-permissions
   govuk-publishing-components
   govuk-publishing-experience
   govuk-publishing-on-platform-content

--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -8,7 +8,7 @@ teams=(
   govuk-forms
   govuk-pay
   govuk-platform-security-reliability
-  govuk-publishing-access-and-permissions-team
+  govuk-publishing-access-and-permissions
   govuk-publishing-components
   govuk-publishing-experience
   govuk-publishing-on-platform-content


### PR DESCRIPTION
These values need to match the key in config/alphagov.yml, i.e. govuk-publishing-access-and-permissions not
govuk-publishing-access-and-permissions-team (which is the name of the Slack channel).