### PR TITLE
Add reminder about reward nominations

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -193,6 +193,10 @@ govuk-datagovuk:
 govuk-developers:
   channel: '#govuk-developers'
   <<: *common_properties
+  quotes_days:
+    - Wednesday
+  quotes:
+    - "Do you know someone who has gone above and beyond? Remember you can <https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/business-and-people-services/gds-people-team/reward-and-recognition|nominate a colleague for a voucher or bonus> at any time."
 
 dev-platform-team:
   channel: '#di-dev-platform-team-internal'


### PR DESCRIPTION
It's all too easy to forget this is a thing, and/or not know where to find more information. Putting it in a Slack reminder should keep it on peoples' radar.

Opted to post on Wednesdays as a number of people have non-working days on Fridays, and messages sent on Mondays may get lost amongst all the other noise at the beginning of the week.