### PR TITLE
Revert "Add digital-identity-architecture for #di-architecture"

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -29,12 +29,6 @@ data-insights:
   channel: '#data-insights'
   <<: *common_properties
 
-di-architecture:
-  channel: '#di-architecture'
-  <<: *common_properties
-  repos:
-    - digital-identity-architecture
-
 data-products:
   channel: '#data-products'
   <<: *common_properties


### PR DESCRIPTION
This removes 'digital-identity-architecture` from Seal by reverting commit 05a8a4403081562548cc5edcc14fe274c1dcdf57.