### PR TITLE
These dependencies are not needed anymore

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,7 @@ ruby File.read(".ruby-version").chomp
 gem "faraday-retry"
 gem "octokit", "~> 7.2"
 gem "rubocop-govuk", require: false
-gem "sinatra"
 gem "slack-poster", "~> 2.2.2"
-gem "thin"
 
 group :test do
   gem "fakefs"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,9 +15,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
-    daemons (1.4.1)
     diff-lcs (1.5.0)
-    eventmachine (1.2.7)
     fakefs (2.5.0)
     faraday (2.7.11)
       base64
@@ -36,8 +34,6 @@ GEM
     language_server-protocol (3.17.0.3)
     method_source (1.0.0)
     minitest (5.19.0)
-    mustermann (3.0.0)
-      ruby2_keywords (~> 0.0.1)
     octokit (7.2.0)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -56,8 +52,6 @@ GEM
     public_suffix (5.0.3)
     racc (1.7.1)
     rack (2.2.8)
-    rack-protection (3.1.0)
-      rack (~> 2.2, >= 2.2.4)
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.8.1)
@@ -113,18 +107,8 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    sinatra (3.1.0)
-      mustermann (~> 3.0)
-      rack (~> 2.2, >= 2.2.4)
-      rack-protection (= 3.1.0)
-      tilt (~> 2.0)
     slack-poster (2.2.2)
       faraday (>= 1.0.0)
-    thin (1.8.2)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
-    tilt (2.2.0)
     timecop (0.9.8)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -146,9 +130,7 @@ DEPENDENCIES
   rake
   rspec
   rubocop-govuk
-  sinatra
   slack-poster (~> 2.2.2)
-  thin
   timecop
   webmock
 


### PR DESCRIPTION
All the code runs in GitHub Actions instead of Heroku now.

https://trello.com/c/GFl9iDLT/3294-move-seal-from-heroku-to-github-actions-3