### PR TITLE
Renames team name and slack channel for mainstream publishing experience

### DIFF
--- a/.github/workflows/dependapanda.yml
+++ b/.github/workflows/dependapanda.yml
@@ -35,7 +35,7 @@ jobs:
             govuk-publishing-access-and-permissions
             govuk-publishing-components
             govuk-publishing-experience
-            govuk-publishing-on-platform-content
+            govuk-publishing-mainstream-experience
             govuk-publishing-platform
             govuk-platform-engineering
             content-interactions-on-platform-govuk

--- a/.github/workflows/morning_seal.yml
+++ b/.github/workflows/morning_seal.yml
@@ -36,7 +36,7 @@ jobs:
             govuk-publishing-access-and-permissions
             govuk-publishing-components
             govuk-publishing-experience
-            govuk-publishing-on-platform-content
+            govuk-publishing-mainstream-experience
             govuk-publishing-platform
             govuk-platform-engineering
             govwifi

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -270,8 +270,8 @@ govuk-publishing-experience:
   compact: true
   <<: *common_properties
 
-govuk-publishing-on-platform-content:
-  channel: '#govuk-publishing-on-platform-content-tech'
+govuk-publishing-mainstream-experience:
+  channel: '#govuk-publishing-mainstream-experience-tech'
   compact: true
   <<: *common_properties
 


### PR DESCRIPTION
The On-Platform-Content-Creation team has been renamed Mainstream Publishing Experience