### PR TITLE
Fix Seal error

### DIFF
--- a/lib/seal.rb
+++ b/lib/seal.rb
@@ -32,7 +32,7 @@ private
                 MessageBuilder.new(team, :seal).build
               end
 
-    return if message.nil?
+    return if message.nil? || message.text.nil?
 
     poster = SlackPoster.new(team.channel, message.mood)
     poster.send_request(message.text)


### PR DESCRIPTION
This should hopefully fix the error we're seeing when the Seal runs in the morning:

```
Error sending request: undefined method `as_json' for nil:NilClass

      body = message.is_a?(String) ? options.merge(text: message) : options.merge(message.as_json)
```