### PR TITLE
Add CI pipeline auditing

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -1,0 +1,46 @@
+name: "CI Checks"
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron:  '00 9 * * 1-5' # Runs at 9:00, Monday through Friday.
+
+env:
+  SEAL_ORGANISATION: alphagov
+  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+jobs:
+  ci-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: CI Checks
+        id: ci_checks
+        run: |
+          teams=(
+            ai-govuk
+            govuk-developers
+            govuk-frontenders
+            govuk-navigation-tech
+            govuk-platform-engineering
+            govuk-platform-security-reliability-team
+            govuk-publishing-access-and-permissions-team
+            govuk-publishing-experience-tech
+            govuk-publishing-mainstream-experience-tech
+            govuk-publishing-platform
+            govuk-search-improvement
+            tech-content-interactions-on-platform-govuk
+            user-experience-measurement-govuk-robot-invasion
+          )
+          
+          for team in ${teams[*]} ; do
+            ./bin/seal_runner.rb $team ci
+          done

--- a/ignored_ci_repos.yml
+++ b/ignored_ci_repos.yml
@@ -1,0 +1,11 @@
+- govuk-dns-tf
+- govuk-docker
+- govuk-exporter
+- govuk-helm-charts
+- govuk-mirror
+- govuk-pact-broker
+- govuk-replatform-test-app
+- govuk-rota-announcer
+- govuk-secrets
+- govuk-user-reviewer
+- router

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -16,6 +16,8 @@ class MessageBuilder
     case @mode
     when :panda
       build_dependapanda_message
+    when :ci
+      build_ci_message
     else
       build_regular_message
     end
@@ -57,6 +59,18 @@ private
     end
   end
 
+  def build_ci_message
+    Message.new(ci_message, mood: "robot_face")
+  end
+
+  def ci_message
+    @repos = check_team_repos_ci.reject { |_,v| v }.keys
+    return nil if @repos.empty?
+
+    template_file = TEMPLATE_DIR + "list_ci_issues.text.erb"
+    ERB.new(template_file.read, trim_mode: '-').result(binding).strip
+  end
+
   def pr_date(pr)
     pr[:marked_ready_for_review_at] || pr[:created]
   end
@@ -67,6 +81,10 @@ private
 
   def pull_requests
     @pull_requests ||= github_fetcher.list_pull_requests
+  end
+
+  def check_team_repos_ci
+    @check_team_repos_ci ||= github_fetcher.check_team_repos_ci
   end
 
   def old_pull_requests

--- a/lib/seal.rb
+++ b/lib/seal.rb
@@ -28,6 +28,8 @@ private
                 Message.new(team.quotes.sample) if team.quotes_days.map(&:downcase).include?(Date.today.strftime("%A").downcase)
               when "dependapanda"
                 MessageBuilder.new(team, :panda).build
+              when "ci"
+                MessageBuilder.new(team, :ci).build
               else
                 MessageBuilder.new(team, :seal).build
               end

--- a/lib/slack_poster.rb
+++ b/lib/slack_poster.rb
@@ -57,6 +57,8 @@ private
       [":#{@season_symbol}seal_of_approval:", "#{@season_name}Seal of Approval"]
     when "angry"
       [":#{@season_symbol}angrier_seal:", "#{@season_name}Angry Seal"]
+    when "robot_face"
+      [":robot_face:", "Angry CI Robot"]
     when "tea"
       [":manatea:", "Tea Seal"]
     when "charter"

--- a/templates/list_ci_issues.text.erb
+++ b/templates/list_ci_issues.text.erb
@@ -1,0 +1,4 @@
+The following repos are missing <<%= "https://docs.publishing.service.gov.uk/manual/dependency-review.html" %>|<%= html_encode("SCA") %>> and <<%= "https://docs.publishing.service.gov.uk/manual/codeql.html" %>|<%= html_encode("SAST") %>> scans in their CI pipelines (.github/workflows/ci.yml):
+<% @repos.each do |repo| -%>
+<<%= "https://github.com/alphagov/#{repo}" %>|<%= html_encode(repo) %>>
+<% end -%>


### PR DESCRIPTION
Add a workflow that will run daily and detect which repos don’t have SAST or SCA scans in their CI pipelines and notify the team that owns the repos via a Slack message.

https://trello.com/c/VGvhTJDb/3362-implement-audit-process-to-ensure-sast-and-sca-scans-run-on-all-govuk-repos-5