### PR TITLE
Add SNYK security analysis workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,12 @@ jobs:
   dependency-review:
     name: Dependency Review scan
     uses: alphagov/govuk-infrastructure/.github/workflows/dependency-review.yml@main
-      
+
+  snyk-security:
+    name: SNYK security analysis
+    uses: alphagov/govuk-infrastructure/.github/workflows/snyk-security.yml@main
+    secrets: inherit
+
   tests:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Add SNYK security analysis workflow.

We want to have  SAST and SCA scans embedded into every repository’s CI pipeline so we can ensure our apps are secure.

Documentation: https://docs.publishing.service.gov.uk/manual/snyk.html

https://trello.com/c/RPICx1Qm/3366-add-snyk-sast-and-sca-scans-to-all-govuk-repos-2