### PR TITLE
Update ai-govuk team slack channel names

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -38,9 +38,9 @@ jobs:
             govuk-publishing-platform
             govuk-search-improvement
             tech-content-interactions-on-platform-govuk
-            user-experience-measurement-govuk-robot-invasion
+            dev-notifications-ai-govuk
           )
-          
+
           for team in ${teams[*]} ; do
             ./bin/seal_runner.rb $team ci
           done

--- a/.github/workflows/dependapanda.yml
+++ b/.github/workflows/dependapanda.yml
@@ -38,9 +38,9 @@ jobs:
             govuk-platform-engineering
             content-interactions-on-platform-govuk
             navigation-and-homepage-govuk
-            user-experience-measurement-govuk
+            ai-govuk
           )
-          
+
           for team in ${teams[*]}; do
             ./bin/seal_runner.rb $team dependapanda
             sleep 60

--- a/.github/workflows/morning_seal.yml
+++ b/.github/workflows/morning_seal.yml
@@ -40,22 +40,22 @@ jobs:
             govwifi
             content-interactions-on-platform-govuk
             navigation-and-homepage-govuk
-            user-experience-measurement-govuk
+            ai-govuk
           )
-          
+
           for team in ${teams[*]}; do
             ./bin/seal_runner.rb $team
           done
-          
+
           morning_quote_teams=(
             fun-workstream-govuk
             fun-workstream-gds-community
             govuk-green-team
             navigation-and-homepage-govuk
             dev-platform-team
-            user-experience-measurement-govuk
+            ai-govuk
           )
-          
+
           for team in ${morning_quote_teams[*]}; do
             ./bin/seal_runner.rb $team quotes
           done

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -328,21 +328,18 @@ navigation-and-homepage-govuk:
     - Is your work waiting to be reviewed? Make sure to ask someone.
     - Did you learn something cool recently? Share it with your fellow devs!
 
-user-experience-measurement-govuk:
-  channel: '#user-experience-measurement-govuk-robot-invasion'
+ai-govuk:
+  channel: '#dev-notifications-ai-govuk'
   compact: true
   <<: *common_properties
-quotes:
-    - What do you call a failed robot invasion? A botched invasion!
-    - What do you call a robot who likes to row? A row-bot!
-    - What’s the name of a robot’s favourite restaurant? Megabytes!
-    - What do robot dogs do? They byte!
-    - Why did the robot fail its exam? They were a bit rusty!
-    - What is a robot's favourite music? Heavy metal!
-    - What do robots eat for snacks? Micro chips!
-quotes_days:
-  - Monday
-  - Friday
+  quotes:
+    - Why was the chatbot always calm? Because it had a great CTRL over its emotions!
+    - Why do programmers prefer dark mode? Because light attracts bugs!
+    - Why did the AI break up with its algorithm partner? Because it couldn't find the right parameters for a meaningful relationship!
+    - What's a computer's favourite snack? Microchips with a side of cookies!
+  quotes_days:
+    - Monday
+    - Friday
 
 proj-early-talent-assigned-learning:
   channel: '#proj-early-talent-assigned-learning'


### PR DESCRIPTION
[Trello](https://trello.com/c/Ls0VAovK/737-junior-dev-suitable-change-the-name-of-the-user-experience-measurement-govuk-robot-invasion-slack-channel-and-move-the-various-n)

This PR moves the `user-experience-measurement-govuk-robot-invastion` notifications to `dev-notifications-ai-govuk`. It also replaces the team name from `user-experience-measurement-govuk` to `ai-govuk`.

The previous channel name was causing confusion, so we replaced this to `dev-notifications-ai-govuk`.