### PR TITLE
Add di-infrastructure to the morning seal workflow

### DIFF
--- a/.github/workflows/morning_seal.yml
+++ b/.github/workflows/morning_seal.yml
@@ -26,6 +26,7 @@ jobs:
         id: morning_seal
         run: |
           teams=(
+            di-authentication
             govuk-datagovuk
             govuk-developers
             govuk-forms

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -370,3 +370,9 @@ proj-early-talent-assigned-learning:
     - learningtime-hh-sem1-gov-location-service
     - learningtime-an-sem
   security_alerts: false
+
+di-authentication:
+  channel: '#di-authentication-notifications'
+  <<: *common_properties
+  repos:
+    - di-infrastructure


### PR DESCRIPTION
# What

Add alphagov/di-infrastructure to do PR notifications for the DI auth team

# Why

This repo hasn't been moved over to the new organisation yet, and we'd like notifications for PRs to it.

Second half of work started in govuk-one-login/seal#44