### PR TITLE
PP-12218: Add paas-grafana-annotation-resource to pay repos

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -210,6 +210,7 @@ govuk-pay:
     - WIP
   repos:
     - gds-apple-developer-account-governance
+    - paas-grafana-annotation-resource
     - pay-adot
     - pay-adminusers
     - pay-api-docs-generator


### PR DESCRIPTION
Pay have taken over paas-grafana-annotation-resource, add it to Pays seal repos.