### PR TITLE
Update ignored_ci_repos.yml

### DIFF
--- a/ignored_ci_repos.yml
+++ b/ignored_ci_repos.yml
@@ -1,3 +1,4 @@
+- govuk-developer-docs
 - govuk-dns-tf
 - govuk-docker
 - govuk-exporter


### PR DESCRIPTION
This is a temporary fix to stop the [Slack alerts](https://gds.slack.com/archives/CAB4Q3QBW/p1709715767524859) after https://github.com/alphagov/govuk-developer-docs/pull/4536 was merged.