### PR TITLE
Stop Seal from messaging on bank holidays

### DIFF
--- a/lib/bank_holidays.rb
+++ b/lib/bank_holidays.rb
@@ -1,0 +1,19 @@
+require "date"
+require "json"
+require "net/http"
+
+class Date
+  def self.bank_holidays
+    @bank_holidays ||= Net::HTTP.get(URI("https://www.gov.uk/bank-holidays.json"))
+      .then { JSON.parse _1 }
+      .dig("england-and-wales", "events")
+      .map { |e| Date.iso8601(e["date"]) }
+    rescue StandardError => e
+      puts "Error fetching bank holidays JSON: #{e.message}"
+      []
+  end
+
+  def bank_holiday?
+    Date.bank_holidays.include? self
+  end
+end

--- a/lib/seal.rb
+++ b/lib/seal.rb
@@ -13,6 +13,8 @@ class Seal
   end
 
   def bark(mode: nil)
+    return if Date.today.bank_holiday?
+
     teams.each do |team|
       bark_at(team, mode:)
     end

--- a/spec/bank_holidays_spec.rb
+++ b/spec/bank_holidays_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+require_relative "../lib/bank_holidays"
+
+RSpec.describe Date do
+  before do
+    example_bank_holiday_data = {
+      "england-and-wales": {
+        "division": "england-and-wales",
+        "events": [
+          {
+            "title": "New Year’s Day",
+            "date": "2024-01-01",
+            "notes": "",
+            "bunting": true,
+          },
+          {
+            "title": "Good Friday",
+            "date": "2024-03-29",
+            "notes": "",
+            "bunting": false,
+          },
+        ],
+      },
+    }
+    stub_request(:get, "https://www.gov.uk/bank-holidays.json")
+      .to_return(status: 200, body: example_bank_holiday_data.to_json)
+  end
+
+  describe ".bank_holidays" do
+    it "returns all bank holidays as an array" do
+      expect(Date.bank_holidays).to eq([Date.new(2024, 1, 1), Date.new(2024, 3, 29)])
+    end
+  end
+
+  describe "#bank_holiday?" do
+    it "returns true if the date is a bank holiday" do
+      expect(Date.new(2024, 1, 1).bank_holiday?).to eq(true)
+    end
+
+    it "returns false if the date is not a bank holiday" do
+      expect(Date.new(2018, 3, 28).bank_holiday?).to eq(false)
+    end
+  end
+end

--- a/spec/seal_spec.rb
+++ b/spec/seal_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Seal do
   describe ".bark(mode: nil)" do
     before do
       allow(SlackPoster).to receive(:new).and_return(slack_poster)
+      allow(Date).to receive(:bank_holidays).and_return([])
     end
 
     it "barks at all teams" do
@@ -46,6 +47,14 @@ RSpec.describe Seal do
         expect(MessageBuilder).to receive(:new).with(team, :seal).and_return(message_builder)
         expect(SlackPoster).to receive(:new).with(team.channel, anything)
       end
+
+      subject.bark
+    end
+
+    it "doesn't bark on bank holidays" do
+      allow(Date).to receive(:bank_holidays).and_return([Date.today])
+
+      expect(MessageBuilder).not_to receive(:new)
 
       subject.bark
     end


### PR DESCRIPTION
To reduce unnecessary noise on Slack. 

This is particularly annoying when on-call during bank holidays (if you can't be bothered to figure out how to change notifications on a work phone).