### PR TITLE
Require bank_holidays in Seal class

### DIFF
--- a/lib/seal.rb
+++ b/lib/seal.rb
@@ -3,6 +3,7 @@
 require "bundler/setup"
 Bundler.require(:default)
 
+require_relative "bank_holidays"
 require_relative "message_builder"
 require_relative "slack_poster"
 


### PR DESCRIPTION
This got missed resulting in 

```
/home/runner/work/seal/seal/lib/seal.rb:16:in `bark': undefined method `bank_holiday?' for an instance of Date (NoMethodError)

    return if Date.today.bank_holiday?
                        ^^^^^^^^^^^^^^
```