### PR TITLE
Remove manually added list of repos

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -288,8 +288,6 @@ govuk-publishing-components:
   <<: *common_properties
   dependapanda: true
   seal_prs: true
-  repos:
-    - govuk_publishing_components
 
 govuk-publishing-experience-tech:
   channel: '#govuk-publishing-experience-tech'


### PR DESCRIPTION
GOV.UK teams cannot specify repos in the config, these are pulled from the dev docs

https://trello.com/c/2ucOpKId/3455-simplify-configuration-architecture-for-seal-dependapanda-3