### PR TITLE
Fix Dependapanda

### DIFF
--- a/lib/seal.rb
+++ b/lib/seal.rb
@@ -31,8 +31,8 @@ private
                 send_quotes_message(team, mode)
               when "dependapanda"
                 if team.dependapanda
-                  MessageBuilder.new(team, :panda).build
                   sleep 60 # to prevent rate-limiting
+                  MessageBuilder.new(team, :panda).build
                 end
               when "ci"
                 MessageBuilder.new(team, :ci).build if team.ci_checks


### PR DESCRIPTION
sleep 60 actually returns 60, so it was overwriting the message.

https://trello.com/c/2ucOpKId/3455-simplify-configuration-architecture-for-seal-dependapanda-3