### PR TITLE
Ignore rubocop-govuk in CI checks

### DIFF
--- a/ignored_ci_repos.yml
+++ b/ignored_ci_repos.yml
@@ -10,3 +10,4 @@
 - govuk-secrets
 - govuk-user-reviewer
 - router
+- rubocop-govuk


### PR DESCRIPTION
This repo has only configuration, without any code. Therefore, the scans do not work as intended, causing the workflow to fail.

https://github.com/alphagov/rubocop-govuk/pull/364