### PR TITLE
Revert "Add Brakeman check"

### DIFF
--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -157,9 +157,8 @@ private
     ci_file = Base64.decode64(github.contents("#{organisation}/#{repo}", path: ".github/workflows/ci.yml").content)
     sca_string = "uses: alphagov/govuk-infrastructure/.github/workflows/dependency-review.yml@main"
     sast_string = "uses: alphagov/govuk-infrastructure/.github/workflows/codeql-analysis.yml@main"
-    brakeman_string = "uses: alphagov/govuk-infrastructure/.github/workflows/brakeman.yml@main"
 
-    ci_file.include?(sca_string) && ci_file.include?(sast_string) && ci_file.include?(brakeman_string)
+    ci_file.include?(sca_string) && ci_file.include?(sast_string)
   rescue Octokit::NotFound
     true # if a CI file is not present assume no scans are needed
   end

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -281,7 +281,7 @@ RSpec.describe GithubFetcher do
 
   describe "CI checks" do
     let(:bad_ci_file) { double(Sawyer::Resource, content: "rubbish") }
-    let(:good_ci_file) { double(Sawyer::Resource, content: "dXNlczogYWxwaGFnb3YvZ292dWstaW5mcmFzdHJ1Y3R1cmUvLmdpdGh1Yi93\nb3JrZmxvd3MvZGVwZW5kZW5jeS1yZXZpZXcueW1sQG1haW4KdXNlczogYWxw\naGFnb3YvZ292dWstaW5mcmFzdHJ1Y3R1cmUvLmdpdGh1Yi93b3JrZmxvd3Mv\nY29kZXFsLWFuYWx5c2lzLnltbEBtYWluCnVzZXM6IGFscGhhZ292L2dvdnVr\nLWluZnJhc3RydWN0dXJlLy5naXRodWIvd29ya2Zsb3dzL2JyYWtlbWFuLnlt\nbEBtYWlu\n") }
+    let(:good_ci_file) { double(Sawyer::Resource, content: "dXNlczogYWxwaGFnb3YvZ292dWstaW5mcmFzdHJ1Y3R1cmUvLmdpdGh1Yi93\nb3JrZmxvd3MvZGVwZW5kZW5jeS1yZXZpZXcueW1sQG1haW4KdXNlczogYWxw\naGFnb3YvZ292dWstaW5mcmFzdHJ1Y3R1cmUvLmdpdGh1Yi93b3JrZmxvd3Mv\nY29kZXFsLWFuYWx5c2lzLnltbEBtYWluCg==\n") }
     let(:use_labels) { false }
     let(:repos) { %w[repo1] }
 

--- a/templates/list_ci_issues.text.erb
+++ b/templates/list_ci_issues.text.erb
@@ -1,4 +1,4 @@
-Please check that the following repos have <<%= "https://docs.publishing.service.gov.uk/manual/dependency-review.html" %>|<%= html_encode("SCA") %>>, <<%= "https://docs.publishing.service.gov.uk/manual/codeql.html" %>|<%= html_encode("SAST") %>> and <<%= "https://docs.publishing.service.gov.uk/manual/brakeman.html" %>|<%= html_encode("Brakeman") %>> scans in their CI pipelines (.github/workflows/ci.yml):
+Please check that the following repos have <<%= "https://docs.publishing.service.gov.uk/manual/dependency-review.html" %>|<%= html_encode("SCA") %>> and <<%= "https://docs.publishing.service.gov.uk/manual/codeql.html" %>|<%= html_encode("SAST") %>> scans in their CI pipelines (.github/workflows/ci.yml):
 <% @repos.each do |repo| -%>
 <<%= "https://github.com/alphagov/#{repo}" %>|<%= html_encode(repo) %>>
 <% end -%>


### PR DESCRIPTION
The check needs to be limited to Ruby on Rails apps and account for repos that don't use re-usable workflow.