### PR TITLE
Add CI check ignore reasons

### DIFF
--- a/ignored_ci_repos.yml
+++ b/ignored_ci_repos.yml
@@ -10,4 +10,3 @@
 - govuk-rota-announcer      # Private repo (contains PII)
 - govuk-user-reviewer       # Private repo (contains PII)
 - router
-- rubocop-govuk

--- a/ignored_ci_repos.yml
+++ b/ignored_ci_repos.yml
@@ -1,13 +1,13 @@
 - govuk-developer-docs
-- govuk-dns-tf
+- govuk-dns-tf              # Private repo, no IaC scanning
 - govuk-dns-ui              # Private repo
-- govuk-docker
+- govuk-docker              # Used for local development, no container scanning
 - govuk-exporter
-- govuk-helm-charts
+- govuk-helm-charts         # No IaC scanning
 - govuk-mirror
-- govuk-pact-broker
+- govuk-pact-broker         # No container scanning
 - govuk-replatform-test-app
-- govuk-rota-announcer
-- govuk-user-reviewer
+- govuk-rota-announcer      # Private repo (contains PII)
+- govuk-user-reviewer       # Private repo (contains PII)
 - router
 - rubocop-govuk


### PR DESCRIPTION
To document why a repos is ignored from checks.
Security scanning will be added later on to repos that have no reason stated.

[Trello](https://trello.com/c/ohqrwfD6/3541-manually-audit-security-scans)