### PR TITLE
Update ignored_ci_repos.yml

### DIFF
--- a/ignored_ci_repos.yml
+++ b/ignored_ci_repos.yml
@@ -1,4 +1,3 @@
-- govuk-developer-docs
 - govuk-dns-tf              # Private repo, no IaC scanning
 - govuk-dns-ui              # Private repo
 - govuk-docker              # Used for local development, no container scanning


### PR DESCRIPTION
The dev docs security scans are in a different workflow, which we now check