### PR TITLE
Add slack webhook type

### DIFF
--- a/.github/workflows/verify_repo_tags.yml
+++ b/.github/workflows/verify_repo_tags.yml
@@ -59,3 +59,4 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
This line is needed so that we can link to the failed workflow.