### PR TITLE
Fix Data Insights Slack channel name and turn on Dependapanda

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -48,9 +48,10 @@ govuk-patterns-and-pages:
   dependapanda: true
   seal_prs: true
 
-data-insights:
-  channel: '#data-insights'
+data-engineering:
+  channel: '#data-engineering'
   <<: *common_properties
+  dependapanda: true
 
 di-authentication:
   channel: '#di-authentication-notifications'

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -48,16 +48,8 @@ govuk-patterns-and-pages:
   dependapanda: true
   seal_prs: true
 
-data-infrastructure:
-  channel: '#data-infrastructure'
-  <<: *common_properties
-
 data-insights:
   channel: '#data-insights'
-  <<: *common_properties
-
-data-products:
-  channel: '#data-products'
   <<: *common_properties
 
 di-authentication:


### PR DESCRIPTION
- Fixes the Slack channel name for the team and turns on Dependapanda for them
- Removes defunct teams