### PR TITLE
Add `pay-run-amock` to Pay Repos

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -239,6 +239,7 @@ govuk-pay:
     - pay-products-ui
     - pay-publicapi
     - pay-publicauth
+    - pay-run-amock
     - pay-selfservice
     - pay-set-up-pre-commit
     - pay-smoke-tests


### PR DESCRIPTION
## What?
We have been asked to add the `pay-run-amock` repo to Seal Notifications for the Pay team.

Requested by Joe Roberts from GOV.UK Pay