### PR TITLE
Update Slack channel for GOV.UK Publishing Platform team

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -278,7 +278,7 @@ govuk-publishing-mainstream-experience-tech:
   seal_prs: true
 
 govuk-publishing-platform:
-  channel: '#govuk-publishing-platform'
+  channel: '#govuk-publishing-platform-system-alerts'
   compact: true
   <<: *common_properties
   dependapanda: true


### PR DESCRIPTION
The team have set up a dedicated Slack channel for automated alerts, so updating Seal and Dependapanda to post there instead.

[Trello card](https://trello.com/c/NKbo84JK)