### PR TITLE
Allow alerts to be posted to a different Slack channel

### DIFF
--- a/lib/team_builder.rb
+++ b/lib/team_builder.rb
@@ -96,7 +96,7 @@ private
   end
 
   def govuk_team_repos(team_channel)
-    @govuk_data.select { |repos| repos["team"] == team_channel }.map { |repo| repo["app_name"] }
+    @govuk_data.select { |repos| repos["alerts_team"] == team_channel }.map { |repo| repo["app_name"] }
   rescue StandardError => e
     puts "Error fetching govuk team repos (#{team_channel}): #{e.message}"
     []

--- a/spec/team_builder_spec.rb
+++ b/spec/team_builder_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe TeamBuilder do
   let(:uri) { URI("https://docs.publishing.service.gov.uk/repos.json") }
 
   let(:repos) do
-    [{ "app_name" => "Brazil", "team" => "#govuk-jaguars" },
-     { "app_name" => "rainforest", "team" => "#govuk-wildcats-team" },
-     { "app_name" => "savanna", "team" => "#govuk-wildcats-team" },
-     { "app_name" => "grassland", "team" => "#govuk-wildcats-team" },
-     { "app_name" => "generic-repo", "team" => "govuk-generic-team" }]
+    [{ "app_name" => "Brazil", "alerts_team" => "#govuk-jaguars" },
+     { "app_name" => "rainforest", "alerts_team" => "#govuk-wildcats-team" },
+     { "app_name" => "savanna", "alerts_team" => "#govuk-wildcats-team" },
+     { "app_name" => "grassland", "alerts_team" => "#govuk-wildcats-team" },
+     { "app_name" => "generic-repo", "alerts_team" => "govuk-generic-team" }]
   end
 
   before do


### PR DESCRIPTION
At the moment, PR review reinders are sent to the Slack channel of the team who own the application.

Some teams may wish to have automated alerting sent to a different channel. Therefore updating to use the `alerts_team` value instead of the `team` value.

By default, `govuk-developer-docs` [falls back to the `team` value](https://github.com/alphagov/govuk-developer-docs/blob/b5241f5c2202330ac8488fce3ce1fe8c681bb472/app/repo.rb#L145-L146) where no other value is specified.

[Trello card](https://trello.com/c/NKbo84JK)