### PR TITLE
Update `is_govuk_team?` method

### DIFF
--- a/lib/team_builder.rb
+++ b/lib/team_builder.rb
@@ -103,6 +103,6 @@ private
   end
 
   def is_govuk_team?(team)
-    @govuk_data.any? { |repo| repo["team"] == "##{team}" }
+    @govuk_data.any? { |repo| repo["alerts_team"] == "##{team}" }
   end
 end


### PR DESCRIPTION
In https://github.com/alphagov/seal/pull/570, we added the ability to post alerts to a different Slack channel to the main team.

Changing the hash key in this method was missed.