### PR TITLE
Update govuk-platform-engineering slack channel

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -251,7 +251,7 @@ govuk-pay:
     - pool-resource
 
 govuk-platform-engineering:
-  channel: '#govuk-platform-engineering'
+  channel: '#govuk-platform-support'
   compact: true
   <<: *common_properties
   dependapanda: true


### PR DESCRIPTION
It was changed in https://github.com/alphagov/govuk-developer-docs/pull/4915 and those have to match for the seal to pick up team's repos.