### PR TITLE
Remove alphagov/forms from govuk-forms repos

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -184,7 +184,6 @@ govuk-forms:
   dependapanda: true
   seal_prs: true
   repos:
-    - forms
     - forms-admin
     - forms-api
     - forms-e2e-tests


### PR DESCRIPTION
We use this repo for in-depth content-heavy changes (e.g ADRs and design documentation) so changes almost always exceed seal's time limits. We've decided to remove it from the config so that we can focus on our app repos.