### PR TITLE
Add CodeQL security alerts

### DIFF
--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -50,6 +50,10 @@ class GithubFetcher
     @security_alert_handler&.github_api_errors || 0
   end
 
+  def code_scanning_alerts_count
+    @security_alert_handler&.code_scanning_alerts_count
+  end
+
 private
 
   attr_reader :use_labels,

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -159,8 +159,10 @@ private
     @all_prs_count = @repos.sum { |repo| repo[:pr_count] }
 
     if @team.security_alerts
-      @all_alerts_count = github_fetcher.security_alerts_count
-      @all_alerts_link = "https://github.com/orgs/alphagov/security/alerts/dependabot?q=is:open+repo:#{@team.repos.join(',')}"
+      @dependabot_alerts_count = github_fetcher.security_alerts_count
+      @dependabot_alerts_link = "https://github.com/orgs/alphagov/security/alerts/dependabot?q=is:open+repo:#{@team.repos.join(',')}"
+      @code_scanning_alerts_count = github_fetcher.code_scanning_alerts_count
+      @code_scanning_alerts_link = "https://github.com/orgs/alphagov/security/alerts/code-scanning?query=is:open+repo:#{@team.repos.join(',')}"
       @github_api_errors = github_fetcher.github_api_errors
 
       security_prs = @repos.flat_map { |repo| repo[:security_prs] }

--- a/spec/message_builder_spec.rb
+++ b/spec/message_builder_spec.rb
@@ -4,12 +4,13 @@ require "./lib/message_builder"
 RSpec.describe MessageBuilder do
   let(:security_alerts) { false }
   let(:security_alerts_count) { 0 }
+  let(:code_scanning_alerts_count) { 0 }
   let(:github_api_errors) { 0 }
   let(:repos) { %w[repo1 repo2] }
   let(:team) { double(:team, security_alerts:, compact: false, dependency_prs:, repos:) }
   let(:pull_requests) { [] }
   let(:dependency_prs) { false }
-  let(:github_fetcher) { double(:github_fetcher, list_pull_requests: pull_requests, security_alerts_count:, github_api_errors:) }
+  let(:github_fetcher) { double(:github_fetcher, list_pull_requests: pull_requests, security_alerts_count:, code_scanning_alerts_count:, github_api_errors:) }
   let(:animal) { :seal }
   subject(:message_builder) { MessageBuilder.new(team, animal) }
 
@@ -341,36 +342,38 @@ RSpec.describe MessageBuilder do
     context "security_alerts=True, dependabot PRs present" do
       let(:security_alerts) { true }
       let(:security_alerts_count) { 1 }
+      let(:code_scanning_alerts_count) { 0 }
       let(:pull_requests) { dependabot_pull_requests }
 
       it "posts a message with security info" do
         expect(message_builder.build.text).to include("You have 2 automatic dependency upgrade PRs open on the following apps:")
-        expect(message_builder.build.text).to include("1 security alert")
+        expect(message_builder.build.text).to include("1 Dependabot security alert")
       end
 
       let(:github_api_errors) { 2 }
 
       it "shows a warning if there are API errors" do
         expect(message_builder.build.text).to include(":warning: 2 errors fetching security alerts.")
-        expect(message_builder.build.text).to include("1 security alert")
+        expect(message_builder.build.text).to include("1 Dependabot security alert")
       end
     end
 
     context "security_alerts=True, Renovate PRs present" do
       let(:security_alerts) { true }
       let(:security_alerts_count) { 1 }
+      let(:code_scanning_alerts_count) { 0 }
       let(:pull_requests) { renovate_pull_requests }
 
       it "posts a message with security info" do
         expect(message_builder.build.text).to include("You have 1 automatic dependency upgrade PR open on the following app:")
-        expect(message_builder.build.text).to include("1 security alert")
+        expect(message_builder.build.text).to include("1 Dependabot security alert")
       end
 
       let(:github_api_errors) { 2 }
 
       it "shows a warning if there are API errors" do
         expect(message_builder.build.text).to include(":warning: 2 errors fetching security alerts.")
-        expect(message_builder.build.text).to include("1 security alert")
+        expect(message_builder.build.text).to include("1 Dependabot security alert")
       end
     end
   end

--- a/spec/security_alert_handler_spec.rb
+++ b/spec/security_alert_handler_spec.rb
@@ -57,6 +57,14 @@ RSpec.describe SecurityAlertHandler do
         accept: "application/vnd.github+json",
         state: "open",
       ).and_return(api_response)
+
+      allow(github).to receive(:get).with(
+        "https://api.github.com/repos/test-org/#{repo}/code-scanning/alerts",
+        accept: "application/vnd.github+json",
+      ).and_return([
+        { state: "open" },
+        { state: "closed" },
+      ])
     end
 
     allow(handler).to receive(:fetch_security_alerts).and_return(sample_alerts)
@@ -73,9 +81,9 @@ RSpec.describe SecurityAlertHandler do
         expect(handler.security_alerts_count).to eq(0)
       end
 
-      it "returns 2 for github_api_errors" do
+      it "returns 4 for github_api_errors" do
         handler = SecurityAlertHandler.new(github, organisation, repos)
-        expect(handler.github_api_errors).to eq(2)
+        expect(handler.github_api_errors).to eq(4)
       end
     end
 

--- a/templates/dependapanda.text.erb
+++ b/templates/dependapanda.text.erb
@@ -5,11 +5,13 @@
 <% end -%>
 
 <% if @team.security_alerts %>
-<%= ":#{@all_alerts_count.zero? ? 'tada' : 'alert'}: There #{@all_alerts_count == 1 ? 'is' : 'are'} a total of <#{@all_alerts_link}|#{@all_alerts_count == 1 ? '1 security alert' : "#{@all_alerts_count} security alerts"}> across all of your repos.#{' :tada:' if @all_alerts_count.zero?}" -%>
+<%= ":#{@code_scanning_alerts_count.zero? ? 'tada' : 'alert'}: There #{@code_scanning_alerts_count == 1 ? 'is' : 'are'} a total of <#{@code_scanning_alerts_link}|#{@code_scanning_alerts_count == 1 ? '1 Code Scanning security alert' : "#{@code_scanning_alerts_count} Code Scanning security alerts"}> across all of your repos.#{' :tada:' if @code_scanning_alerts_count.zero?}" -%>
+
+<%= ":#{@dependabot_alerts_count.zero? ? 'tada' : 'alert'}: There #{@dependabot_alerts_count == 1 ? 'is' : 'are'} a total of <#{@dependabot_alerts_link}|#{@dependabot_alerts_count == 1 ? '1 Dependabot security alert' : "#{@dependabot_alerts_count} Dependabot security alerts"}> across all of your repos.#{' :tada:' if @dependabot_alerts_count.zero?}" -%>
 <% if @github_api_errors.positive? %>
 <%= ":warning: #{@github_api_errors} errors fetching security alerts. Check that you have the <#{'https://docs.publishing.service.gov.uk/manual/configure-github-repo.html#when-you-create-a-new-repo'}|right permissions> on all <#{'https://docs.publishing.service.gov.uk/repos.html#repos-by-team'}|your repos>." %>
 <% end %>
-<%= "Please prioritise reviewing #{@security_prs_ordered.length == 1 ? 'this PR' : 'these PRs'} to resolve #{@security_prs_ordered.length != @all_alerts_count ? 'some of ' : ''}them:" if @security_prs_ordered.any? %>
+<%= "Please prioritise reviewing #{@security_prs_ordered.length == 1 ? 'this PR' : 'these PRs'} to resolve #{@security_prs_ordered.length != @dependabot_alerts_count ? 'some of ' : ''}them:" if @security_prs_ordered.any? %>
 
 <% @security_prs_ordered.each do |security_pr| -%>
 <%= "<#{security_pr[:pr_link]}|#{security_pr[:pr_title]}> (<#{security_pr[:security_label][:url]}|#{security_pr[:security_label][:count] > 1 ? "#{security_pr[:security_label][:count]} solvable alerts" : "1 solvable alert"}>, highest severity: #{security_pr[:security_label][:severity]})" %>


### PR DESCRIPTION
As a GOV.UK developer
I want to be told about all security vulnerabilities on the repos owned by my team so that I can assess the vulnerabilities and either fix them, or mark them as dismissed (with a reason)

https://github.com/alphagov/govuk-platform-internal/issues/3