### PR TITLE
Fix panda message when there are no PRs

### DIFF
--- a/templates/dependapanda.text.erb
+++ b/templates/dependapanda.text.erb
@@ -1,9 +1,16 @@
-<%= @all_prs_count > 1 ? "You have #{@all_prs_count} automatic dependency upgrade PRs open on the following apps:" : "You have 1 automatic dependency upgrade PR open on the following app:" %>
+<%= if @all_prs_count == 1
+      "You have 1 automatic dependency upgrade PR open on the following app:"
+    elsif @all_prs_count > 1
+      "You have #{@all_prs_count} automatic dependency upgrade PRs open on the following apps:"
+    end %>
 
 <% @repos.each do |repo| -%>
-<<%= repo[:repo_url] %>|<%= html_encode(repo[:repo_name]) %>> (<%= repo[:pr_count] %>, <%= "#{repo[:pr_count] > 1 ? "oldest: #{days_plural(repo[:oldest_pr])}, newest: #{days_plural(repo[:newest_pr])})" : "opened #{days_plural(repo[:oldest_pr])})"}" %>
+<<%= repo[:repo_url] %>|<%= html_encode(repo[:repo_name]) %>> (<%= repo[:pr_count] %>, <%= repo[:pr_count] > 1 ?
+  "oldest: #{days_plural(repo[:oldest_pr])}, newest: #{days_plural(repo[:newest_pr])})" :
+  "opened #{days_plural(repo[:oldest_pr])})" %>
 <% end -%>
 <% if @team.security_alerts %>
+
 <% if @code_scanning_alerts_count.positive? -%>
 <%= ":alert: There #{@code_scanning_alerts_count == 1 ? 'is' : 'are'} a total of <#{@code_scanning_alerts_link}|#{@code_scanning_alerts_count == 1 ? '1 Code Scanning security alert' : "#{@code_scanning_alerts_count} Code Scanning security alerts"}> across all of your repos." -%>
 <% end -%>
@@ -13,12 +20,18 @@
 <% end -%>
 
 <% if @github_api_errors.positive? -%>
-<%= ":warning: #{@github_api_errors} errors fetching security alerts. Check that you have the <#{'https://docs.publishing.service.gov.uk/manual/github-new-repo.html'}|right permissions> on all <#{'https://docs.publishing.service.gov.uk/repos.html#repos-by-team'}|your repos>." -%>
+<%= ":warning: #{@github_api_errors} errors fetching security alerts. Check that you have the <https://docs.publishing.service.gov.uk/manual/github-new-repo.html|right permissions> on all <https://docs.publishing.service.gov.uk/repos.html#repos-by-team|your repos>." -%>
 <% end -%>
 
-<%= "Please prioritise reviewing #{@security_prs_ordered.length == 1 ? 'this PR' : 'these PRs'} to resolve #{@security_prs_ordered.length != @dependabot_alerts_count ? 'some of ' : ''}them:" if @security_prs_ordered.any? %>
+<%= if @security_prs_ordered.any?
+      "Please prioritise reviewing #{@security_prs_ordered.length == 1 ? 'this PR' : 'these PRs'} " \
+      "to resolve #{@security_prs_ordered.length != @dependabot_alerts_count ? 'some of ' : ''}them:"
+    end %>
 
 <% @security_prs_ordered.each do |security_pr| -%>
-<%= "<#{security_pr[:pr_link]}|#{security_pr[:pr_title]}> (<#{security_pr[:security_label][:url]}|#{security_pr[:security_label][:count] > 1 ? "#{security_pr[:security_label][:count]} solvable alerts" : "1 solvable alert"}>, highest severity: #{security_pr[:security_label][:severity]})" %>
+<%= "<#{security_pr[:pr_link]}|#{security_pr[:pr_title]}> " \
+    "(<#{security_pr[:security_label][:url]}|" \
+    "#{security_pr[:security_label][:count] > 1 ? "#{security_pr[:security_label][:count]} solvable alerts" : "1 solvable alert"}>, " \
+    "highest severity: #{security_pr[:security_label][:severity]})" %>
 <% end -%>
 <% end %>


### PR DESCRIPTION
This fixes the problem where a Slack message gets posted by Dependapanda when there are no PRs open.

I also attempted to make the template a little more legible.