### PR TITLE
Opt `govuk-toolbox-image` out of mandatory CI security scans

### DIFF
--- a/ignored_ci_repos.yml
+++ b/ignored_ci_repos.yml
@@ -9,5 +9,6 @@
 - govuk-pact-broker            # No container scanning
 - govuk-replatform-test-app
 - govuk-rota-announcer         # Private repo (contains PII)
+- govuk-toolbox-image          # No container scanning
 - govuk-user-reviewer          # Private repo (contains PII)
 - router


### PR DESCRIPTION
This repo defines an OCI container image for running ad hoc tasks on Kubernetes (in Dockerfile). We currently don't have container scanning.

https://github.com/alphagov/govuk-infrastructure/issues/2961