### PR TITLE
Improve failure alerting

### DIFF
--- a/.github/workflows/afternoon_seal_quotes.yml
+++ b/.github/workflows/afternoon_seal_quotes.yml
@@ -25,3 +25,10 @@ jobs:
         id: afternoon_seal_quotes
         run: |
           ./bin/seal_runner.rb afternoon_seal_quotes
+
+      - if: ${{ failure() }}
+        uses: alphagov/govuk-infrastructure/.github/actions/report-run-failure@main
+        with:
+          slack_webhook_url: ${{ secrets.GOVUK_SLACK_WEBHOOK_URL }}
+          channel: govuk-platform-support
+          message: "Afternoon Seal Quotes workflow failed"

--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -26,3 +26,10 @@ jobs:
         id: ci_checks
         run: |
           ./bin/seal_runner.rb ci
+
+      - if: ${{ failure() }}
+        uses: alphagov/govuk-infrastructure/.github/actions/report-run-failure@main
+        with:
+          slack_webhook_url: ${{ secrets.GOVUK_SLACK_WEBHOOK_URL }}
+          channel: govuk-platform-support
+          message: "CI Checks workflow failed"

--- a/.github/workflows/gem_version_checker.yml
+++ b/.github/workflows/gem_version_checker.yml
@@ -26,3 +26,10 @@ jobs:
         id: gem_version_checker
         run: |
           ./bin/seal_runner.rb gems
+
+      - if: ${{ failure() }}
+        uses: alphagov/govuk-infrastructure/.github/actions/report-run-failure@main
+        with:
+          slack_webhook_url: ${{ secrets.GOVUK_SLACK_WEBHOOK_URL }}
+          channel: govuk-platform-support
+          message: "Gem Version Checker workflow failed"

--- a/.github/workflows/morning_seal_quotes.yml
+++ b/.github/workflows/morning_seal_quotes.yml
@@ -25,3 +25,10 @@ jobs:
         id: morning_seal_quotes
         run: |
           ./bin/seal_runner.rb morning_seal_quotes
+
+      - if: ${{ failure() }}
+        uses: alphagov/govuk-infrastructure/.github/actions/report-run-failure@main
+        with:
+          slack_webhook_url: ${{ secrets.GOVUK_SLACK_WEBHOOK_URL }}
+          channel: govuk-platform-support
+          message: "Morning Seal Quotes workflow failed"

--- a/.github/workflows/verify_repo_tags.yml
+++ b/.github/workflows/verify_repo_tags.yml
@@ -43,7 +43,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "The <https://github.com/alphagov/govuk-developer-docs/blob/main/data/repos.yml|Developer Docs repo list> is out of sync with the repos tagged as 'govuk' in GitHub."
+                    "text": "The <https://github.com/alphagov/govuk-developer-docs/blob/main/data/repos.yml|Developer Docs repo list> is out of sync with the repos tagged as 'govuk' in GitHub. <https://docs.google.com/document/d/12W_OiSSH-cs_MTzBwT66anRDFDOwmx-7RKF_U0u9vVM/edit?tab=t.0#heading=h.ddohqbdt0uqc|See the runbook>"
                   },
                   "accessory": {
                     "type": "button",

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -24,22 +24,6 @@ class MessageBuilder
     else
       build_regular_message
     end
-  rescue StandardError => e
-    puts "Error building message: #{e.message}"
-    alert_slack(e.message)
-    nil
-  end
-
-  def alert_slack(message)
-    slack_options =
-      {
-        icon_emoji: ":sad-seal:",
-        username: "Seal error",
-        channel: "#govuk-platform-support",
-      }
-
-    poster = Slack::Poster.new(ENV["SLACK_WEBHOOK"].to_s, slack_options)
-    poster.send_message("The Seal has encountered an error running in mode #{@mode}: #{message}")
   end
 
   def rotten?(pull_request)


### PR DESCRIPTION
- Introduces a new job in the workflow to alert on failures, allowing for better tracking and visibility of issues including issued with Slack integration.
- Removes error handling that previously rescued `MessageBuilder` errors, which caused 30-35 notifications
- Minor downside: The script will now stop if a single message fails, but this scenario is unlikely based on past behaviour.

It also adds a link to a runbook, as we had instances of engineers attempting to silence the alert without addressing the issue it was alerting us about.