### PR TITLE
Remove forms-api from dependapanda config

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -184,7 +184,6 @@ govuk-forms:
   seal_prs: true
   repos:
     - forms-admin
-    - forms-api
     - forms-e2e-tests
     - forms-runner
     - forms-product-page


### PR DESCRIPTION
We're getting rid of the forms-api repo, so we no longer need dependency notifications about it.