### PR TITLE
Ignore search-api-v2-dataform

### DIFF
--- a/ignored_ci_repos.yml
+++ b/ignored_ci_repos.yml
@@ -12,3 +12,4 @@
 - govuk-toolbox-image          # No container scanning
 - govuk-user-reviewer          # Private repo (contains PII)
 - router
+- search-api-v2-dataform       # Used to define SQL scripts for use in GCP


### PR DESCRIPTION
The search team are getting the following error every morning: 1 errors fetching security alerts

It looks as though this is due to the fact that [search-api-v2-dataform] is listed as a repo they own, but does not have dependabot set up. Dependabot is not needed because it is a repo of sql queries and does not have any dependencies.

[search-api-v2-dataform]: https://github.com/alphagov/govuk-developer-docs/blob/main/data/repos.yml#L695