### PR TITLE
Add forms-deploy repo to GOV.UK Forms config

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -195,6 +195,7 @@ govuk-forms:
     - forms-runner
     - forms-product-page
     - govuk-forms-markdown
+    - forms-deploy
   security_alerts: false
 
 govuk-green-team:


### PR DESCRIPTION
Our infra team recently made this repo public (🎉) meaning it's now visible to Seal, so we can add it to the config