### PR TITLE
Change DGU slack channel used by the Seal

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -168,7 +168,7 @@ fun-workstream-govuk:
     - Friday
 
 govuk-datagovuk:
-  channel: '#govuk-datagovuk'
+  channel: '#datagovuk-technical'
   <<: *common_properties
   dependapanda: true
   seal_prs: true


### PR DESCRIPTION
This makes sure the Seal posts to the correct channel, which has changed its name. 

Same change made in the developer docs here https://github.com/alphagov/govuk-developer-docs/pull/5344 but I forgot this one. 