### PR TITLE
Make public channel guidance clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Features:
 
 Add your team's configuration to [config/alphagov.yml](https://github.com/alphagov/seal/blob/main/config/alphagov.yml). The process is slightly different depending on whether or not your team is part of GOV.UK.
 
+> The Seal can only post to public channels.
+
 ### GOV.UK teams
 
 Include your team's name and the Slack channel you want to post to. These *must match the team name and Slack channel* specified in the [Developer Docs](https://docs.publishing.service.gov.uk/repos.html#repos-by-team). Do not add a list of repos, they will be pulled from the developer docs automatically. Private repos are not currently supported.
@@ -47,7 +49,7 @@ To customize which alerts your team channel gets, find your team in [config/alph
 
 ### Local testing
 
-To test the script, create a private Slack channel e.g. "#angry-seal-bot-test-abc" and update `@team_channel` on [this line in slack_poster.rb](https://github.com/alphagov/seal/blob/fe03ae1d2637d2fcd69816344e26a4a6e0696ffb/lib/slack_poster.rb#L108) to the one you created, you'll also need a `DEVELOPMENT` env set to `true`.
+To test the script, create a Slack channel e.g. "#angry-seal-bot-test-abc" and update `@team_channel` on [this line in slack_poster.rb](https://github.com/alphagov/seal/blob/fe03ae1d2637d2fcd69816344e26a4a6e0696ffb/lib/slack_poster.rb#L108) to the one you created, you'll also need a `DEVELOPMENT` env set to `true`.
 You can then run the [GitHub Action](https://github.com/alphagov/seal/actions) selecting your branch and you should see the post in your test channel.
 
 If you don't want to post to Slack you can add a `DRY: true` env to your workflow and the output will only show in the logs.


### PR DESCRIPTION
It wasn't obvious, so making it clearer might avoid confusion in future. 

See also https://github.com/alphagov/govuk-developer-docs/pull/5376 