### PR TITLE
Add DGU repos to alert on

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -41,6 +41,19 @@ ai-govuk:
     - Monday
     - Friday
 
+datagovuk:
+  channel: '#datagovuk-technical'
+  <<: *common_properties
+  dependapanda: true
+  seal_prs: true
+  repos:
+    - govuk-dgu-charts
+    - ckan-mock-harvest-sources
+    - ckanext-datagovuk
+    - ckanext-spatial
+    - datagovuk-tech-docs
+    - datagovuk_find
+
 di-authentication:
   channel: '#di-authentication-notifications'
   <<: *common_properties
@@ -147,12 +160,6 @@ fun-workstream-govuk:
     - Monday
     - Wednesday
     - Friday
-
-govuk-datagovuk:
-  channel: '#datagovuk-technical'
-  <<: *common_properties
-  dependapanda: true
-  seal_prs: true
 
 govuk-developers:
   channel: '#govuk-developers'


### PR DESCRIPTION
Description:
- These repos are now managed by DGU not GOV.UK
- https://github.com/alphagov/govuk-infrastructure/issues/3586