### PR TITLE
Update search team slack channel

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -301,7 +301,7 @@ govuk-publishing-platform:
   seal_prs: true
 
 govuk-search:
-  channel: '#govuk-search'
+  channel: '#govuk-search-tech'
   compact: true
   <<: *common_properties
   dependapanda: true


### PR DESCRIPTION
The GOV.UK Search team have recently created a new slack channel for technical notifications & PR requests. This PR moves seal notifications to post in the new channel.

There is a [companion PR in govuk-developer-docs](https://github.com/alphagov/govuk-developer-docs/pull/5434) that I think will need to be merged first.