### PR TITLE
Link to Dependabot PRs across all repos

### DIFF
--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -135,6 +135,7 @@ private
     @repos = panda_presenter
 
     @all_prs_count = @repos.sum { |repo| repo[:pr_count] }
+    @all_prs_link = "https://github.com/search?q=is:pr+is:open+label:dependencies+#{@team.repos.map { "repo:alphagov/#{it}" }.join('+')}"
 
     if @team.security_alerts
       @dependabot_alerts_count = github_fetcher.security_alerts_count

--- a/spec/message_builder_spec.rb
+++ b/spec/message_builder_spec.rb
@@ -311,7 +311,7 @@ RSpec.describe MessageBuilder do
       let(:security_alerts) { false }
 
       it "posts a message without security info" do
-        expect(message_builder.build.text).to include("You have 2 automatic dependency upgrade PRs open on the following apps:")
+        expect(message_builder.build.text).to include("2 automatic dependency upgrade PRs")
         expect(message_builder.build.text).not_to include("security alert")
       end
     end
@@ -321,7 +321,7 @@ RSpec.describe MessageBuilder do
       let(:security_alerts) { false }
 
       it "posts a message without security info" do
-        expect(message_builder.build.text).to include("You have 1 automatic dependency upgrade PR open on the following app:")
+        expect(message_builder.build.text).to include("1 automatic dependency upgrade PR")
         expect(message_builder.build.text).not_to include("security alert")
       end
     end
@@ -367,7 +367,7 @@ RSpec.describe MessageBuilder do
       let(:pull_requests) { dependabot_pull_requests }
 
       it "posts a message with security info" do
-        expect(message_builder.build.text).to include("You have 2 automatic dependency upgrade PRs open on the following apps:")
+        expect(message_builder.build.text).to include("2 automatic dependency upgrade PRs")
         expect(message_builder.build.text).to include("1 Dependabot security alert")
       end
 
@@ -386,7 +386,7 @@ RSpec.describe MessageBuilder do
       let(:pull_requests) { renovate_pull_requests }
 
       it "posts a message with security info" do
-        expect(message_builder.build.text).to include("You have 1 automatic dependency upgrade PR open on the following app:")
+        expect(message_builder.build.text).to include("1 automatic dependency upgrade PR")
         expect(message_builder.build.text).to include("1 Dependabot security alert")
       end
 

--- a/templates/dependapanda.text.erb
+++ b/templates/dependapanda.text.erb
@@ -1,7 +1,7 @@
 <% if @all_prs_count == 1 -%>
-You have 1 automatic dependency upgrade PR open on the following app:
+You have <<%= @all_prs_link %>|1 automatic dependency upgrade PR> open on the following app:
 <% elsif @all_prs_count > 1 -%>
-You have <%= @all_prs_count %> automatic dependency upgrade PRs open on the following apps:
+You have <<%= @all_prs_link %>|<%= @all_prs_count %> automatic dependency upgrade PRs> open on the following apps:
 <% end -%>
 
 <% @repos.each do |repo| -%>


### PR DESCRIPTION
In teams that manage a lot of repositories, it can be annoying keeping track of which repos' dependency PRs you've actioned when working through the Dependapanda list. This adds a link to show all open dependency PRs across all of a team's repos, creating more of a single, unified to do list

For example, in the Publishing Platform team it should generate a link like:

```
https://github.com/search?q=is:pr+is:open+label:dependencies+repo:alphagov/asset-manager+repo:alphagov/authenticating-proxy+repo:alphagov/bouncer+repo:alphagov/content-store+repo:alphagov/gds-api-adapters+repo:alphagov/gds-sso+repo:alphagov/govspeak+repo:alphagov/govspeak-preview+repo:alphagov/govuk-content-api-docs+repo:alphagov/govuk_content_item_loader+repo:alphagov/govuk_message_queue_consumer+repo:alphagov/govuk_schemas+repo:alphagov/govuk_sidekiq+repo:alphagov/hmrc-manuals-api+repo:alphagov/link-checker-api+repo:alphagov/optic14n+repo:alphagov/publishing-api+repo:alphagov/signon+repo:alphagov/support+repo:alphagov/support-api+repo:alphagov/transition
```