### PR TITLE
Rename "Publishing Platform" team to "Content APIs"

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -294,8 +294,8 @@ govuk-publishing-mainstream-experience-tech:
   dependapanda: true
   seal_prs: true
 
-govuk-publishing-platform:
-  channel: '#govuk-publishing-platform-system-alerts'
+govuk-content-apis:
+  channel: '#govuk-content-apis-system-alerts'
   compact: true
   <<: *common_properties
   dependapanda: true


### PR DESCRIPTION
The team is focusing on APIs so the name was changed to reflect that.

Depends on:
- https://github.com/alphagov/govuk-developer-docs/pull/5527