### PR TITLE
Add govuk-rota-generator to ignored CI repos [TECH-29]

### DIFF
--- a/ignored_ci_repos.yml
+++ b/ignored_ci_repos.yml
@@ -9,6 +9,7 @@
 - govuk-pact-broker            # No container scanning
 - govuk-replatform-test-app
 - govuk-rota-announcer         # Private repo (contains PII)
+- govuk-rota-generator         # Private repo (contains PII)
 - govuk-toolbox-image          # No container scanning
 - govuk-user-reviewer          # Private repo (contains PII)
 - router


### PR DESCRIPTION
Added 'govuk-rota-generator' to ignored CI repos list.

Jira: https://gov-uk.atlassian.net/browse/TECH-29