### PR TITLE
Rename govuk-publishing-{content,reuse}- Slack references

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -280,8 +280,8 @@ govuk-publishing-components:
   dependapanda: true
   seal_prs: true
 
-govuk-publishing-content-modelling-dev:
-  channel: '#govuk-publishing-content-modelling-automations'
+govuk-publishing-content-reuse-dev:
+  channel: '#govuk-publishing-content-reuse-automations'
   compact: true
   <<: *common_properties
   dependapanda: true


### PR DESCRIPTION
The "Content Modelling" team in Publishing is changing its name to "Content Reuse".

This PR renames references to the Slack channels used by some integrations with tools:

- `#govuk-publishing-content-modelling-dev`
- `#govuk-publishing-content-modelling-automations`