### PR TITLE
Update GOV.UK Chat notification channel

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -26,7 +26,7 @@ common_properties: &common_properties
     - Friday
 
 ai-govuk:
-  channel: '#dev-notifications-ai-govuk'
+  channel: '#ai-govuk-chat-devs'
   compact: true
   <<: *common_properties
   dependapanda: true


### PR DESCRIPTION
We're now using a combined channel for notifications and dev discussion.