### PR TITLE
Update the team name responsible for govuk-publishing-components

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -273,7 +273,7 @@ govuk-platform-engineering:
   dependapanda: true
   seal_prs: true
 
-govuk-publishing-components:
+govuk-ruby-frontenders:
   channel: '#govuk-publishing-components'
   <<: *common_properties
   dependapanda: true


### PR DESCRIPTION
There was a mismatch between team names in here and dev doc repo and as a result the notifications are not being sent out.

The #govuk-publishing-components channel was created as a departure from people's comments were being overlooked.

Dependency:
- https://github.com/alphagov/govuk-developer-docs/pull/5649